### PR TITLE
feat(devtools): Adiciona templates para seleção de contexto e prompts…

### DIFF
--- a/templates/context_selectors/select-context-for-fix-artisan-dusk.txt
+++ b/templates/context_selectors/select-context-for-fix-artisan-dusk.txt
@@ -1,0 +1,41 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Com base na descrição da tarefa principal e no manifesto JSON fornecido, selecione os arquivos **MAIS RELEVANTES** do manifesto que fornecerão o contexto ótimo para a IA realizar a tarefa principal.
+
+**Tarefa Principal:** Analisar a saída do comando `php artisan dusk` (contida em `dusk_test_results.txt`), identificar os testes que falharam, determinar se o erro está no código do teste Dusk ou no código da aplicação (Blade/Livewire/JS), e gerar o código corrigido para o(s) arquivo(s) apropriado(s). Considerar também os artefatos de falha (screenshots, console logs) que estariam disponíveis em `tests/Browser/screenshots` e `tests/Browser/console`.
+
+**Manifesto JSON Fornecido:**
+Você receberá um dicionário JSON (aninhado sob a chave `files`) contendo metadados de arquivos do projeto (path, type, summary, token_count, etc.). Este manifesto JÁ FOI FILTRADO para excluir arquivos muito grandes.
+
+**Seu Processo de Seleção:**
+1.  Entenda profundamente o objetivo da **Tarefa Principal**: corrigir falhas reportadas em `dusk_test_results.txt`.
+2.  Analise os metadados de CADA arquivo no `manifest.json` fornecido (path, type, summary).
+3.  Selecione APENAS os arquivos CRÍTICOS que contenham:
+    *   **OBRIGATÓRIO:** O resultado da execução dos testes Dusk (`dusk_test_results.txt`).
+    *   **OBRIGATÓRIO:** O(s) arquivo(s) de teste Dusk (`tests/Browser/...Test.php`) específico(s) mencionado(s) como falho(s) no relatório.
+    *   **ALTAMENTE RELEVANTE:** O(s) arquivo(s) de View Blade (`resources/views/...blade.php`) ou Componente Livewire (`resources/views/livewire/...blade.php`) que o teste Dusk falho estava interagindo (inferir do nome do teste, seletores usados no teste ou mensagem de erro).
+    *   **Relevante (se aplicável):** Arquivos JavaScript (`resources/js/...`) se o erro indicar falha de JS no console.
+    *   Os guias de desenvolvimento (`guia_de_desenvolvimento.md`, `padroes_codigos_boas_praticas.md`) para padrões gerais.
+    *   (Opcional) Arquivos base do Dusk (`tests/DuskTestCase.php`, `tests/Browser/Pages/Page.php`) se o erro parecer relacionado à configuração do teste ou Page Objects.
+4.  **Priorize:** O `dusk_test_results.txt`, o teste falho, e a view/componente interagido são essenciais. Guias e JS são importantes para contexto.
+5.  **Exclua:** Testes PHPUnit/PHPStan, código PHP backend não diretamente relacionado à renderização da UI ou lógica Livewire do componente testado, Git logs/diffs, detalhes de issues genéricas, arquivos de configuração não relevantes, dependências, e outros arquivos não diretamente necessários para *diagnosticar e corrigir a falha específica do teste Dusk*.
+
+**Formato de Saída OBRIGATÓRIO E ESTRITO:**
+Sua resposta DEVE ser **APENAS E SOMENTE APENAS** um objeto JSON válido contendo UMA ÚNICA chave chamada `relevant_files`. O valor desta chave DEVE ser uma LISTA (array JSON) de strings, onde cada string é o caminho relativo EXATO de um arquivo selecionado do manifesto.
+
+**Exemplo de Saída:**
+```json
+{
+  "relevant_files": [
+    "context_llm/code/YYYYMMDD_HHMMSS/dusk_test_results.txt",
+    "tests/Browser/LoginTest.php",
+    "resources/views/livewire/pages/auth/login.blade.php",
+    "resources/js/app.js",
+    "docs/padroes_codigo_boas_praticas.md"
+  ]
+}
+```
+
+**REGRAS ADICIONAIS:**
+-   **NÃO** inclua NENHUM texto explicativo, introdução, saudação ou qualquer outra coisa fora do objeto JSON.
+-   Sua resposta completa DEVE começar com `{` e terminar com `}`.
+-   Se NENHUM arquivo for considerado relevante (altamente improvável), retorne `{"relevant_files": []}`.

--- a/templates/context_selectors/select-context-for-fix-artisan-test.txt
+++ b/templates/context_selectors/select-context-for-fix-artisan-test.txt
@@ -1,0 +1,40 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Com base na descrição da tarefa principal e no manifesto JSON fornecido, selecione os arquivos **MAIS RELEVANTES** do manifesto que fornecerão o contexto ótimo para a IA realizar a tarefa principal.
+
+**Tarefa Principal:** Analisar a saída do comando `php artisan test` (contida em `phpunit_test_results.txt`), identificar os testes que falharam, determinar se o erro está no código do teste ou no código da aplicação referenciado, e gerar o código PHP corrigido para o(s) arquivo(s) apropriado(s).
+
+**Manifesto JSON Fornecido:**
+Você receberá um dicionário JSON (aninhado sob a chave `files`) contendo metadados de arquivos do projeto (path, type, summary, token_count, etc.). Este manifesto JÁ FOI FILTRADO para excluir arquivos muito grandes.
+
+**Seu Processo de Seleção:**
+1.  Entenda profundamente o objetivo da **Tarefa Principal**: corrigir falhas reportadas em `phpunit_test_results.txt`.
+2.  Analise os metadados de CADA arquivo no `manifest.json` fornecido (path, type, summary).
+3.  Selecione APENAS os arquivos CRÍTICOS que contenham:
+    *   **OBRIGATÓRIO:** O resultado da execução dos testes (`phpunit_test_results.txt`). Este é o arquivo mais importante para identificar as falhas.
+    *   **OBRIGATÓRIO:** Os arquivos de teste (`tests/...Test.php`) específicos que são mencionados como falhos no `phpunit_test_results.txt`.
+    *   **ALTAMENTE RELEVANTE:** Os arquivos de código da aplicação (`app/...`) que são diretamente mencionados nas mensagens de erro ou stack traces dentro do `phpunit_test_results.txt`.
+    *   Os guias de desenvolvimento (`guia_de_desenvolvimento.md`, `padroes_codigos_boas_praticas.md`) que definem os padrões de código e teste.
+    *   (Opcional, se relevante para o erro) Outros arquivos PHP (Models, Services, Traits, Interfaces) que são dependências diretas do código que falhou (seja no teste ou na aplicação), para que a IA compreenda tipos e assinaturas. Use o `summary` para avaliar a relevância.
+4.  **Priorize:** O `phpunit_test_results.txt`, o(s) arquivo(s) de teste falho(s), e o(s) arquivo(s) da aplicação diretamente implicado(s) são essenciais. Guias de padrões são importantes. Código relacionado é contextual.
+5.  **Exclua:** Arquivos de teste que passaram, diffs de Git, logs de commit, detalhes de issues (a menos que diretamente relacionado ao erro), arquivos de configuração não relevantes, dependências, views Blade, assets, e outros arquivos de contexto não diretamente necessários para *diagnosticar e corrigir as falhas específicas* reportadas nos testes.
+
+**Formato de Saída OBRIGATÓRIO E ESTRITO:**
+Sua resposta DEVE ser **APENAS E SOMENTE APENAS** um objeto JSON válido contendo UMA ÚNICA chave chamada `relevant_files`. O valor desta chave DEVE ser uma LISTA (array JSON) de strings, onde cada string é o caminho relativo EXATO de um arquivo selecionado do manifesto.
+
+**Exemplo de Saída:**
+```json
+{
+  "relevant_files": [
+    "context_llm/code/YYYYMMDD_HHMMSS/phpunit_test_results.txt",
+    "tests/Feature/Auth/FailingAuthenticationTest.php",
+    "app/Http/Controllers/Auth/LoginController.php",
+    "app/Models/User.php",
+    "docs/padroes_codigo_boas_praticas.md"
+  ]
+}
+```
+
+**REGRAS ADICIONAIS:**
+-   **NÃO** inclua NENHUM texto explicativo, introdução, saudação ou qualquer outra coisa fora do objeto JSON.
+-   Sua resposta completa DEVE começar com `{` e terminar com `}`.
+-   Se NENHUM arquivo for considerado relevante (altamente improvável, o `phpunit_test_results.txt` sempre será), retorne `{"relevant_files": []}`.

--- a/templates/context_selectors/select-context-for-fix-phpstan.txt
+++ b/templates/context_selectors/select-context-for-fix-phpstan.txt
@@ -1,0 +1,39 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Com base na descrição da tarefa principal e no manifesto JSON fornecido, selecione os arquivos **MAIS RELEVANTES** do manifesto que fornecerão o contexto ótimo para a IA realizar a tarefa principal.
+
+**Tarefa Principal:** Corrigir os erros de análise estática reportados no arquivo `phpstan_analysis.txt`, gerando o código PHP corrigido para os arquivos afetados, seguindo os padrões do projeto.
+
+**Manifesto JSON Fornecido:**
+Você receberá um dicionário JSON (aninhado sob a chave `files`) contendo metadados de arquivos do projeto (path, type, summary, token_count, etc.). Este manifesto JÁ FOI FILTRADO para excluir arquivos muito grandes.
+
+**Seu Processo de Seleção:**
+1.  Entenda profundamente o objetivo da **Tarefa Principal**: corrigir erros do PHPStan listados em `phpstan_analysis.txt`.
+2.  Analise os metadados de CADA arquivo no `manifest.json` fornecido (path, type, summary).
+3.  Selecione APENAS os arquivos CRÍTICOS que contenham:
+    *   **OBRIGATÓRIO:** O relatório de erros do PHPStan (`phpstan_analysis.txt`). Este é o arquivo mais importante.
+    *   **OBRIGATÓRIO:** Os arquivos `.php` específicos mencionados no relatório `phpstan_analysis.txt` como contendo erros. Você DEVE identificar esses caminhos no manifesto.
+    *   Os guias de desenvolvimento (`guia_de_desenvolvimento.md`, `padroes_codigos_boas_praticas.md`) que definem os padrões de código a serem seguidos.
+    *   (Opcional, se o erro indicar problemas de tipo entre classes) Outros arquivos `.php` (Models, Services, Interfaces, Traits) que sejam diretamente referenciados nos erros ou no código dos arquivos afetados, para que a IA entenda os tipos e assinaturas corretos. Use o `summary` para ajudar a decidir.
+4.  **Priorize:** O `phpstan_analysis.txt` e os arquivos PHP diretamente afetados são essenciais. Os guias de padrões são muito importantes. Arquivos PHP relacionados são contextuais.
+5.  **Exclua:** Diffs de Git, logs de commit, detalhes de issues, arquivos de teste (a menos que o erro esteja *no* teste), arquivos de configuração não relevantes, dependências, views Blade, assets, e outros arquivos de contexto não diretamente necessários para *entender e corrigir os erros específicos* reportados pelo PHPStan.
+
+**Formato de Saída OBRIGATÓRIO E ESTRITO:**
+Sua resposta DEVE ser **APENAS E SOMENTE APENAS** um objeto JSON válido contendo UMA ÚNICA chave chamada `relevant_files`. O valor desta chave DEVE ser uma LISTA (array JSON) de strings, onde cada string é o caminho relativo EXATO de um arquivo selecionado do manifesto.
+
+**Exemplo de Saída:**
+```json
+{
+  "relevant_files": [
+    "context_llm/code/YYYYMMDD_HHMMSS/phpstan_analysis.txt",
+    "app/Http/Controllers/AffectedController.php",
+    "app/Services/SomeService.php",
+    "app/Models/UserModel.php",
+    "docs/padroes_codigo_boas_praticas.md"
+  ]
+}
+```
+
+**REGRAS ADICIONAIS:**
+-   **NÃO** inclua NENHUM texto explicativo, introdução, saudação ou qualquer outra coisa fora do objeto JSON.
+-   Sua resposta completa DEVE começar com `{` e terminar com `}`.
+-   Se NENHUM arquivo for considerado relevante (altamente improvável para esta tarefa, pois o `phpstan_analysis.txt` sempre será), retorne `{"relevant_files": []}`.

--- a/templates/meta-prompts/meta-prompt-fix-artisan-dusk.txt
+++ b/templates/meta-prompts/meta-prompt-fix-artisan-dusk.txt
@@ -1,0 +1,48 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Crie **EXCLUSIVAMENTE** o texto de um **prompt final**. Este prompt final instruirá uma IA (a "IA Final") a corrigir erros de testes do Laravel Dusk reportados no arquivo `dusk_test_results.txt` e potenciais artefatos associados, gerando código PHP/Blade/JS corrigido, utilizando como base este meta-prompt e os arquivos de contexto anexados. **NÃO** inclua **NADA** além do texto puro e exato deste prompt final. **ZERO** introduções, **ZERO** explicações, **ZERO** comentários pré ou pós-prompt. Sua saída deve começar **IMEDIATAMENTE** com a primeira palavra do prompt final e terminar **IMEDIATAMENTE** com a última palavra dele. Qualquer caractere fora do texto do prompt final é **ESTRITAMENTE PROIBIDO**.
+
+**Instruções para a Construção do Prompt Final (QUE VOCÊ DEVE GERAR E NADA MAIS):**
+
+O prompt final que você gerar **DEVE** comandar **explicitamente** a IA Final a seguir **OBRIGATORIAMENTE E SEM EXCEÇÕES** as seguintes diretrizes:
+
+1.  **Objetivo Principal:** Instrua a IA Final a analisar o arquivo `dusk_test_results.txt` (e considerar conceitualmente os artefatos de falha em `tests/Browser/screenshots` e `tests/Browser/console`) fornecido no contexto, identificar os testes Dusk que falharam, diagnosticar se o erro está no código do teste Dusk ou no código da aplicação (Blade/Livewire/JS), e gerar o código **COMPLETO e CORRIGIDO** para o(s) arquivo(s) relevante(s).
+
+2.  **Análise Mandatória do Contexto:** Exija que a IA Final analise **TODOS** os arquivos de contexto anexados, com **ÊNFASE** em:
+    *   `dusk_test_results.txt`: Para identificar os testes exatos que falharam, as mensagens de erro e os stack traces.
+    *   O(s) arquivo(s) de teste Dusk (`tests/Browser/...Test.php`) mencionado(s) como falho(s).
+    *   O(s) arquivo(s) de View Blade (`resources/views/...blade.php`) ou Componente Livewire (`resources/views/livewire/...blade.php`) que o teste provavelmente estava interagindo.
+    *   Arquivos JavaScript (`resources/js/...`) se o erro sugerir problemas de frontend.
+    *   `guia_de_desenvolvimento.md` e `padroes_codigos_boas_praticas.md`: Para garantir que as correções sigam os padrões.
+
+3.  **Diretrizes de Correção Específicas:**
+    *   **Foco nas Falhas:** A IA Final **DEVE** focar **EXCLUSIVAMENTE** em corrigir as falhas específicas listadas em `dusk_test_results.txt`. **NÃO DEVE** fazer refatorações não solicitadas ou adicionar novos testes não relacionados diretamente à correção da falha.
+    *   **Diagnóstico da Causa Raiz:** A IA Final **DEVE** tentar determinar a causa: um seletor Dusk incorreto/instável? Uma espera (`waitFor`, `waitUntil`) inadequada? Um erro de asserção? Um bug real na UI (elemento ausente, classe CSS errada, erro JS, estado Livewire incorreto)?
+    *   **Correção Direcionada:** A IA Final **DEVE** gerar o código corrigido para o arquivo correto (o arquivo de teste Dusk, o arquivo Blade, o componente Livewire ou o arquivo JS).
+    *   **Validade do Código:** O código corrigido **DEVE** ser PHP/Blade/JS válido e sintaticamente correto.
+    *   **Manter Estilo:** As correções **DEVEM** manter o estilo de código e a formatação existentes no arquivo original o máximo possível, aderindo aos padrões PSR-12/Pint (para PHP/Blade) e boas práticas de JS.
+    *   **Impacto Mínimo:** Faça as alterações mínimas necessárias para corrigir o teste Dusk.
+    *   **Seletores Dusk:** Se corrigir o teste Dusk, prefira usar seletores `dusk="..."` estáveis se disponíveis.
+
+4.  **Restrições de Saída da IA Final:**
+    *   **PROIBIÇÃO ABSOLUTA DE MENÇÃO DE ARQUIVOS DE CONTEXTO:** Ordene CATEGORICAMENTE que a IA Final **NÃO mencione NUNCA** nomes de arquivos de contexto (`dusk_test_results.txt`, `.md`, etc.) na saída final ou em comentários.
+    *   **ESTRUTURA DA RESPOSTA FINAL (REFORÇO CRÍTICO):** Ordene que a IA Final forneça **UMA ÚNICA RESPOSTA TEXTUAL**. Esta resposta **DEVE CONTER APENAS E SOMENTE APENAS** a concatenação sequencial do código **COMPLETO e CORRIGIDO** para **CADA ARQUIVO** (PHP, Blade ou JS) que foi modificado para corrigir as falhas. O bloco total de código de arquivo **DEVE** seguir **ESTRITAMENTE** o formato:
+        ```
+        --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+        <?php // Código PHP/Blade completo e corrigido do arquivo... ?>
+        --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+        --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.js ---
+        // Código JS completo e corrigido...
+        --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.js ---
+        ```
+        *   A IA Final **DEVE** incluir o código **COMPLETO** do arquivo modificado, não apenas os trechos alterados.
+        *   O `path/relativo/ao/projeto/arquivo_corrigido.ext` **DEVE** ser o caminho exato do arquivo que continha o erro original ou que precisou ser corrigido.
+        *   A resposta completa da IA Final **NÃO DEVE conter NENHUM prefixo, NENHUM sufixo, NENHUMA explicação, NENHUM comentário fora do código, NENHUMA saudação ou qualquer outro texto FORA** da sequência direta desses blocos `--- START/END ---`.
+        *   A resposta inteira deve começar com o primeiro `--- START OF FILE ...`. Termine imediatamente após o último `--- END OF FILE ...`.
+    *   **SE NENHUMA CORREÇÃO DE CÓDIGO FOR POSSÍVEL/NECESSÁRIA:** Se, após análise, a IA concluir que os erros reportados no `dusk_test_results.txt` são devidos a problemas de ambiente, configuração do ChromeDriver, ou não podem ser resolvidos com alterações nos arquivos de código fornecidos, sua resposta **DEVE ser ABSOLUTAMENTE VAZIA**. Retorne uma string vazia, sem nenhum texto.
+
+5.  **Observação Adicional:** O prompt final **DEVE** incluir a seguinte observação como uma diretriz adicional a ser considerada pela IA Final:
+    ```
+    __OBSERVACAO_ADICIONAL__
+    ```
+
+**REPETINDO SUA TAREFA:** Sua saída deve ser **APENAS** o texto do prompt final que instruirá a IA Final a gerar o código corrigido para as falhas de teste Dusk, seguindo as diretrizes de formato de saída revisadas e utilizando os valores específicos que já estarão presentes neste meta-prompt quando você o processar. Comece a resposta diretamente com a primeira palavra do prompt final. Termine imediatamente após a última palavra. **NÃO ESCREVA MAIS NADA.**

--- a/templates/meta-prompts/meta-prompt-fix-artisan-test.txt
+++ b/templates/meta-prompts/meta-prompt-fix-artisan-test.txt
@@ -1,0 +1,48 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Crie **EXCLUSIVAMENTE** o texto de um **prompt final**. Este prompt final instruirá uma IA (a "IA Final") a corrigir erros de testes do Artisan (PHPUnit) reportados no arquivo `phpunit_test_results.txt`, gerando código PHP corrigido, utilizando como base este meta-prompt e os arquivos de contexto anexados. **NÃO** inclua **NADA** além do texto puro e exato deste prompt final. **ZERO** introduções, **ZERO** explicações, **ZERO** comentários pré ou pós-prompt. Sua saída deve começar **IMEDIATAMENTE** com a primeira palavra do prompt final e terminar **IMEDIATAMENTE** com a última palavra dele. Qualquer caractere fora do texto do prompt final é **ESTRITAMENTE PROIBIDO**.
+
+**Instruções para a Construção do Prompt Final (QUE VOCÊ DEVE GERAR E NADA MAIS):**
+
+O prompt final que você gerar **DEVE** comandar **explicitamente** a IA Final a seguir **OBRIGATORIAMENTE E SEM EXCEÇÕES** as seguintes diretrizes:
+
+1.  **Objetivo Principal:** Instrua a IA Final a analisar o arquivo `phpunit_test_results.txt` fornecido no contexto, identificar os testes que falharam, diagnosticar se o erro está no código do teste ou no código da aplicação, e gerar o código **COMPLETO e CORRIGIDO** para o(s) arquivo(s) PHP relevante(s).
+
+2.  **Análise Mandatória do Contexto:** Exija que a IA Final analise **TODOS** os arquivos de contexto anexados, com **ÊNFASE** em:
+    *   `phpunit_test_results.txt`: Para identificar os testes exatos que falharam, as mensagens de erro e os stack traces.
+    *   Os arquivos de teste (`tests/...Test.php`) mencionados no relatório como falhos.
+    *   Os arquivos de código da aplicação (`app/...`) mencionados nos stack traces ou mensagens de erro.
+    *   `guia_de_desenvolvimento.md` e `padroes_codigos_boas_praticas.md`: Para garantir que as correções sigam os padrões de código do projeto (PSR-12/Pint, nomenclatura, etc.).
+    *   Outros arquivos `.php` relacionados (se fornecidos): Para entender tipos e assinaturas de métodos/classes referenciadas nos erros ou código afetado.
+
+3.  **Diretrizes de Correção Específicas:**
+    *   **Foco nas Falhas:** A IA Final **DEVE** focar **EXCLUSIVAMENTE** em corrigir as falhas específicas listadas em `phpunit_test_results.txt`. **NÃO DEVE** fazer refatorações não solicitadas, otimizações, ou adicionar novos testes não relacionados diretamente à correção da falha.
+    *   **Diagnóstico da Causa Raiz:** A IA Final **DEVE** tentar determinar se a falha é causada por lógica incorreta no teste ou por um bug no código da aplicação sendo testado.
+    *   **Correção Direcionada:** A IA Final **DEVE** gerar o código corrigido para o arquivo correto (seja o arquivo de teste ou o arquivo da aplicação). Se a correção exigir mudanças em ambos (incomum, mas possível), ambos os arquivos completos e corrigidos devem ser fornecidos.
+    *   **Validade do Código:** O código corrigido **DEVE** ser PHP válido e sintaticamente correto para a versão do projeto (Laravel 12 / PHP 8.2+).
+    *   **Manter Estilo:** As correções **DEVEM** manter o estilo de código e a formatação existentes no arquivo original o máximo possível, aderindo aos padrões PSR-12/Pint definidos nos guias.
+    *   **Impacto Mínimo:** As alterações **DEVEM** ser as mínimas necessárias para fazer o teste passar, resolvendo o erro reportado.
+    *   **Nomenclatura/Traduções:** Manter a nomenclatura existente. Não introduzir texto de usuário.
+
+4.  **Restrições de Saída da IA Final:**
+    *   **PROIBIÇÃO ABSOLUTA DE MENÇÃO DE ARQUIVOS DE CONTEXTO:** Ordene CATEGORICAMENTE que a IA Final **NÃO mencione NUNCA** nomes de arquivos de contexto (`phpunit_test_results.txt`, `.md`, etc.) na saída final ou em comentários.
+    *   **ESTRUTURA DA RESPOSTA FINAL (REFORÇO CRÍTICO):** Ordene que a IA Final forneça **UMA ÚNICA RESPOSTA TEXTUAL**. Esta resposta **DEVE CONTER APENAS E SOMENTE APENAS** a concatenação sequencial do código **COMPLETO e CORRIGIDO** para **CADA ARQUIVO PHP** que foi modificado para corrigir as falhas. O bloco total de código de arquivo **DEVE** seguir **ESTRITAMENTE** o formato:
+        ```
+        --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+        <?php // Código PHP completo e corrigido do arquivo... ?>
+        --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+        --- START OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+        <?php // Código PHP completo e corrigido do outro arquivo... ?>
+        --- END OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+        ```
+        *   A IA Final **DEVE** incluir o código **COMPLETO** do arquivo modificado, não apenas os trechos alterados.
+        *   O `path/relativo/ao/projeto/arquivo_corrigido.php` **DEVE** ser o caminho exato do arquivo que continha o erro original ou que precisou ser corrigido.
+        *   A resposta completa da IA Final **NÃO DEVE conter NENHUM prefixo, NENHUM sufixo, NENHUMA explicação, NENHUM comentário fora do código, NENHUMA saudação ou qualquer outro texto FORA** da sequência direta desses blocos `--- START/END ---`.
+        *   A resposta inteira deve começar com o primeiro `--- START OF FILE ...`. Termine imediatamente após o último `--- END OF FILE ...`.
+    *   **SE NENHUMA CORREÇÃO DE CÓDIGO FOR POSSÍVEL/NECESSÁRIA:** Se, após análise, a IA concluir que os erros reportados no `phpunit_test_results.txt` são devidos a problemas de ambiente, configuração, ou não podem ser resolvidos com alterações nos arquivos de código fornecidos, sua resposta **DEVE ser ABSOLUTAMENTE VAZIA**. Retorne uma string vazia, sem nenhum texto.
+
+5.  **Observação Adicional:** O prompt final **DEVE** incluir a seguinte observação como uma diretriz adicional a ser considerada pela IA Final:
+    ```
+    __OBSERVACAO_ADICIONAL__
+    ```
+
+**REPETINDO SUA TAREFA:** Sua saída deve ser **APENAS** o texto do prompt final que instruirá a IA Final a gerar o código corrigido para as falhas de teste, seguindo as diretrizes de formato de saída revisadas e utilizando os valores específicos que já estarão presentes neste meta-prompt quando você o processar. Comece a resposta diretamente com a primeira palavra do prompt final. Termine imediatamente após a última palavra. **NÃO ESCREVA MAIS NADA.**

--- a/templates/meta-prompts/meta-prompt-fix-phpstan.txt
+++ b/templates/meta-prompts/meta-prompt-fix-phpstan.txt
@@ -1,0 +1,47 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Crie **EXCLUSIVAMENTE** o texto de um **prompt final**. Este prompt final instruirá uma IA (a "IA Final") a corrigir erros de PHPStan reportados no arquivo `phpstan_analysis.txt`, gerando código PHP corrigido, utilizando como base este meta-prompt e os arquivos de contexto anexados. **NÃO** inclua **NADA** além do texto puro e exato deste prompt final. **ZERO** introduções, **ZERO** explicações, **ZERO** comentários pré ou pós-prompt. Sua saída deve começar **IMEDIATAMENTE** com a primeira palavra do prompt final e terminar **IMEDIATAMENTE** com a última palavra dele. Qualquer caractere fora do texto do prompt final é **ESTRITAMENTE PROIBIDO**.
+
+**Instruções para a Construção do Prompt Final (QUE VOCÊ DEVE GERAR E NADA MAIS):**
+
+O prompt final que você gerar **DEVE** comandar **explicitamente** a IA Final a seguir **OBRIGATORIAMENTE E SEM EXCEÇÕES** as seguintes diretrizes:
+
+1.  **Objetivo Principal:** Instrua a IA Final a analisar o arquivo `phpstan_analysis.txt` fornecido no contexto e a corrigir **APENAS E SOMENTE APENAS** os erros de análise estática ali reportados, modificando os arquivos PHP relevantes fornecidos no contexto. O objetivo **NÃO** é refatorar ou melhorar o código além do necessário para corrigir os erros do PHPStan.
+
+2.  **Análise Mandatória do Contexto:** Exija que a IA Final analise **TODOS** os arquivos de contexto anexados, com **ÊNFASE** em:
+    *   `phpstan_analysis.txt`: Para identificar os erros exatos, arquivos e linhas afetadas.
+    *   Os arquivos `.php` mencionados no relatório do PHPStan: Para entender o código original e aplicar as correções.
+    *   `guia_de_desenvolvimento.md` e `padroes_codigos_boas_praticas.md`: Para garantir que as correções sigam os padrões de código do projeto (PSR-12/Pint, nomenclatura, etc.).
+    *   Outros arquivos `.php` relacionados (se fornecidos): Para entender tipos e assinaturas de métodos/classes referenciadas nos erros.
+
+3.  **Diretrizes de Correção Específicas:**
+    *   **Foco nos Erros:** A IA Final **DEVE** focar **EXCLUSIVAMENTE** em corrigir os erros listados em `phpstan_analysis.txt`. **NÃO DEVE** fazer refatorações não solicitadas, otimizações ou alterações estilísticas não relacionadas diretamente à correção do erro estático.
+    *   **Precisão:** As correções **DEVEM** resolver o erro específico apontado pelo PHPStan na linha indicada (ou contexto próximo).
+    *   **Validade do Código:** O código corrigido **DEVE** ser PHP válido e sintaticamente correto para a versão do projeto (Laravel 12 / PHP 8.2+).
+    *   **Manter Estilo:** As correções **DEVEM** manter o estilo de código e a formatação existentes no arquivo original o máximo possível, aderindo aos padrões PSR-12/Pint definidos nos guias.
+    *   **Impacto Mínimo:** As alterações **DEVEM** ser as mínimas necessárias para corrigir o erro, evitando reescritas extensas se uma correção pontual for suficiente.
+    *   **Consistência:** Se múltiplos erros similares existirem, as correções **DEVEM** ser consistentes.
+    *   **Nomenclatura/Traduções:** Manter a nomenclatura existente. Não introduzir texto de usuário (não é esperado para correções PHPStan).
+
+4.  **Restrições de Saída da IA Final:**
+    *   **PROIBIÇÃO ABSOLUTA DE MENÇÃO DE ARQUIVOS DE CONTEXTO:** Ordene CATEGORICAMENTE que a IA Final **NÃO mencione NUNCA** nomes de arquivos de contexto (`phpstan_analysis.txt`, `.md`, etc.) na saída final ou em comentários.
+    *   **ESTRUTURA DA RESPOSTA FINAL (REFORÇO CRÍTICO):** Ordene que a IA Final forneça **UMA ÚNICA RESPOSTA TEXTUAL**. Esta resposta **DEVE CONTER APENAS E SOMENTE APENAS** a concatenação sequencial do código **COMPLETO e CORRIGIDO** para **CADA ARQUIVO PHP** que foi modificado. O bloco total de código de arquivo **DEVE** seguir **ESTRITAMENTE** o formato:
+        ```
+        --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+        <?php // Código PHP completo e corrigido do arquivo... ?>
+        --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+        --- START OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+        <?php // Código PHP completo e corrigido do outro arquivo... ?>
+        --- END OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+        ```
+        *   A IA Final **DEVE** incluir o código **COMPLETO** do arquivo modificado, não apenas os trechos alterados.
+        *   O `path/relativo/ao/projeto/arquivo_corrigido.php` **DEVE** ser o caminho exato do arquivo que continha o erro original.
+        *   A resposta completa da IA Final **NÃO DEVE conter NENHUM prefixo, NENHUM sufixo, NENHUMA explicação, NENHUM comentário fora do código, NENHUMA saudação ou qualquer outro texto FORA** da sequência direta desses blocos `--- START/END ---`.
+        *   A resposta inteira deve começar com o primeiro `--- START OF FILE ...`. Termine imediatamente após o último `--- END OF FILE ...`.
+    *   **SE NENHUMA CORREÇÃO FOR NECESSÁRIA:** Se, após análise, a IA concluir que os erros reportados no `phpstan_analysis.txt` não requerem alteração nos arquivos de código fornecidos (talvez por serem erros de configuração ou não relacionados ao código em si), sua resposta **DEVE ser ABSOLUTAMENTE VAZIA**. Retorne uma string vazia, sem nenhum texto.
+
+5.  **Observação Adicional:** O prompt final **DEVE** incluir a seguinte observação como uma diretriz adicional a ser considerada pela IA Final:
+    ```
+    __OBSERVACAO_ADICIONAL__
+    ```
+
+**REPETINDO SUA TAREFA:** Sua saída deve ser **APENAS** o texto do prompt final que instruirá a IA Final a gerar o código corrigido, seguindo as diretrizes de formato de saída revisadas e utilizando os valores específicos que já estarão presentes neste meta-prompt quando você o processar. Comece a resposta diretamente com a primeira palavra do prompt final. Termine imediatamente após a última palavra. **NÃO ESCREVA MAIS NADA.**

--- a/templates/prompts/prompt-fix-artisan-dusk.txt
+++ b/templates/prompts/prompt-fix-artisan-dusk.txt
@@ -1,0 +1,38 @@
+Sua tarefa é analisar o arquivo `dusk_test_results.txt` fornecido no contexto, identificar os testes Laravel Dusk que falharam, diagnosticar a causa raiz (erro no teste, erro na UI, erro JS, etc.) e gerar **APENAS E SOMENTE APENAS** o código PHP/Blade/JS **COMPLETO e CORRIGIDO** para o(s) arquivo(s) necessário(s) para resolver essas falhas. Considere também que artefatos visuais (screenshots, logs de console) estariam disponíveis nos diretórios `tests/Browser/screenshots` e `tests/Browser/console`.
+
+**Analise TODOS os arquivos de contexto anexados**, com **ÊNFASE** em:
+*   `dusk_test_results.txt`: Identifique os testes falhos, mensagens de erro e stack traces.
+*   O(s) arquivo(s) de teste Dusk (`tests/Browser/...Test.php`) indicados como falhos.
+*   O(s) arquivo(s) de View Blade/Livewire (`resources/views/...blade.php`) que o teste interagia.
+*   Arquivos JavaScript (`resources/js/...`) se relevante para o erro.
+*   `guia_de_desenvolvimento.md` e `padroes_codigos_boas_praticas.md`: Para padrões.
+
+Siga **OBRIGATORIAMENTE, SEM EXCEÇÕES E COM MÁXIMA FIDELIDADE** estas regras de implementação:
+
+1.  **Foco nas Falhas:** Corrija **APENAS** as falhas listadas em `dusk_test_results.txt`. Não refatore ou adicione testes não relacionados.
+2.  **Diagnóstico:** Determine a causa: seletor Dusk inválido? Problema de timing (falta `waitFor`)? Erro de asserção? Bug na UI (HTML/CSS/JS)? Erro no componente Livewire?
+3.  **Correção Direcionada:** Gere código corrigido para o arquivo correto (teste Dusk, Blade, Livewire, JS).
+4.  **Validade e Tecnologia:** O código corrigido **DEVE** ser PHP/Blade/JS válido.
+5.  **Manter Estilo:** As correções **DEVEM** manter o estilo (PSR-12/Pint para PHP/Blade, boas práticas JS) e formatação do arquivo original.
+6.  **Impacto Mínimo:** Faça as alterações mínimas necessárias para o teste Dusk passar.
+7.  **Seletores Dusk:** Se corrigir o teste, prefira seletores `dusk="..."`.
+8.  **PROIBIÇÃO DE REFERÊNCIAS:** **NUNCA** mencione nomes de arquivos de contexto não versionados na saída ou em comentários.
+9.  **SAÍDA ESTRITAMENTE FORMATADA:** Sua resposta **DEVE** conter **APENAS E SOMENTE APENAS** a concatenação sequencial do código **COMPLETO e CORRIGIDO** para **CADA ARQUIVO** modificado, no formato **ESTRITO**:
+
+    --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+    <?php // Código PHP/Blade completo e corrigido do arquivo... ?>
+    --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+    --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.js ---
+    // Código JS completo e corrigido...
+    --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.js ---
+
+    *   Use o caminho exato do arquivo original nos marcadores.
+    *   Inclua o código **COMPLETO** do arquivo modificado.
+    *   **NENHUM** texto extra (introdução, explicação, etc.) fora dos blocos `--- START/END ---`.
+    *   Comece diretamente com o primeiro `--- START OF FILE ...`. Termine imediatamente após o último `--- END OF FILE ...`.
+10. **SE NENHUMA CORREÇÃO DE CÓDIGO FOR POSSÍVEL/NECESSÁRIA:** Se concluir que os erros são de ambiente, configuração, ou não podem ser corrigidos com o código fornecido, sua resposta **DEVE SER ABSOLUTAMENTE VAZIA** (string vazia).
+
+**OBSERVAÇÃO ADICIONAL PRIORITÁRIA:**
+__OBSERVACAO_ADICIONAL__
+
+Execute a tarefa seguindo **TODAS** estas regras com **MÁXIMA FIDELIDADE**.

--- a/templates/prompts/prompt-fix-artisan-test.txt
+++ b/templates/prompts/prompt-fix-artisan-test.txt
@@ -1,0 +1,37 @@
+Sua tarefa é analisar o arquivo `phpunit_test_results.txt` fornecido no contexto, identificar os testes que falharam, diagnosticar a causa raiz (erro no teste ou no código da aplicação) e gerar **APENAS E SOMENTE APENAS** o código PHP **COMPLETO e CORRIGIDO** para o(s) arquivo(s) necessário(s) para resolver essas falhas.
+
+**Analise TODOS os arquivos de contexto anexados**, com **ÊNFASE** em:
+*   `phpunit_test_results.txt`: Identifique os testes falhos, mensagens de erro e stack traces.
+*   Arquivos de teste (`tests/...Test.php`) indicados como falhos.
+*   Arquivos da aplicação (`app/...`) mencionados nos erros/stack traces.
+*   `guia_de_desenvolvimento.md` e `padroes_codigos_boas_praticas.md`: Para padrões de código.
+*   Arquivos PHP relacionados (se houver): Para contexto de tipos/assinaturas.
+
+Siga **OBRIGATORIAMENTE, SEM EXCEÇÕES E COM MÁXIMA FIDELIDADE** estas regras de implementação:
+
+1.  **Foco nas Falhas:** Corrija **APENAS** as falhas listadas em `phpunit_test_results.txt`. Não refatore ou adicione testes não relacionados.
+2.  **Diagnóstico:** Determine se a falha está no teste ou na aplicação.
+3.  **Correção Direcionada:** Gere código corrigido para o arquivo correto (teste ou aplicação). Se ambos precisarem de ajuste, forneça ambos.
+4.  **Validade e Tecnologia:** O código corrigido **DEVE** ser PHP válido (Laravel 12 / PHP 8.2+).
+5.  **Manter Estilo:** As correções **DEVEM** manter o estilo (PSR-12/Pint) e formatação do arquivo original.
+6.  **Impacto Mínimo:** Faça as alterações mínimas necessárias para o teste passar.
+7.  **PROIBIÇÃO DE REFERÊNCIAS:** **NUNCA** mencione nomes de arquivos de contexto não versionados na saída ou em comentários.
+8.  **SAÍDA ESTRITAMENTE FORMATADA:** Sua resposta **DEVE** conter **APENAS E SOMENTE APENAS** a concatenação sequencial do código **COMPLETO e CORRIGIDO** para **CADA ARQUIVO PHP** modificado, no formato **ESTRITO**:
+
+    --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+    <?php // Código PHP completo e corrigido do arquivo... ?>
+    --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+    --- START OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+    <?php // Código PHP completo e corrigido do outro arquivo... ?>
+    --- END OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+
+    *   Use o caminho exato do arquivo original nos marcadores.
+    *   Inclua o código **COMPLETO** do arquivo modificado.
+    *   **NENHUM** texto extra (introdução, explicação, etc.) fora dos blocos `--- START/END ---`.
+    *   Comece diretamente com o primeiro `--- START OF FILE ...`. Termine imediatamente após o último `--- END OF FILE ...`.
+9.  **SE NENHUMA CORREÇÃO DE CÓDIGO FOR POSSÍVEL/NECESSÁRIA:** Se concluir que os erros são de ambiente ou não podem ser corrigidos com as informações/código fornecidos, sua resposta **DEVE SER ABSOLUTAMENTE VAZIA** (string vazia).
+
+**OBSERVAÇÃO ADICIONAL PRIORITÁRIA:**
+__OBSERVACAO_ADICIONAL__
+
+Execute a tarefa seguindo **TODAS** estas regras com **MÁXIMA FIDELIDADE**.

--- a/templates/prompts/prompt-fix-phpstan.txt
+++ b/templates/prompts/prompt-fix-phpstan.txt
@@ -1,0 +1,36 @@
+Sua tarefa é analisar o arquivo `phpstan_analysis.txt` fornecido no contexto e corrigir **APENAS E SOMENTE APENAS** os erros de análise estática ali reportados, modificando os arquivos PHP relevantes fornecidos no contexto. O objetivo **NÃO** é refatorar ou melhorar o código além do necessário para corrigir os erros do PHPStan.
+
+**Analise TODOS os arquivos de contexto anexados**, com **ÊNFASE** em:
+*   `phpstan_analysis.txt`: Para identificar os erros exatos, arquivos e linhas afetadas.
+*   Os arquivos `.php` mencionados no relatório do PHPStan: Para entender o código original e aplicar as correções.
+*   `guia_de_desenvolvimento.md` e `padroes_codigos_boas_praticas.md`: Para garantir que as correções sigam os padrões de código do projeto.
+*   Outros arquivos `.php` relacionados (se fornecidos): Para entender tipos e assinaturas.
+
+Siga **OBRIGATORIAMENTE, SEM EXCEÇÕES E COM MÁXIMA FIDELIDADE** estas regras de implementação:
+
+1.  **Foco Exclusivo:** Corrija **APENAS** os erros listados em `phpstan_analysis.txt`. Não faça refatorações não solicitadas ou alterações estilísticas não relacionadas à correção.
+2.  **Precisão:** As correções **DEVEM** resolver o erro específico apontado pelo PHPStan na linha indicada (ou contexto próximo).
+3.  **Validade e Tecnologia:** O código corrigido **DEVE** ser PHP válido (Laravel 12 / PHP 8.2+).
+4.  **Manter Estilo:** As correções **DEVEM** manter o estilo de código e a formatação existentes no arquivo original o máximo possível, aderindo aos padrões PSR-12/Pint definidos nos guias.
+5.  **Impacto Mínimo:** Faça as alterações mínimas necessárias.
+6.  **Consistência:** Aplique correções consistentes para erros similares.
+7.  **PROIBIÇÃO DE REFERÊNCIAS:** **NUNCA** mencione nomes de arquivos de contexto (`phpstan_analysis.txt`, `.md`) na saída ou em comentários.
+8.  **SAÍDA ESTRITAMENTE FORMATADA:** Sua resposta **DEVE** conter **APENAS E SOMENTE APENAS** a concatenação sequencial do código **COMPLETO e CORRIGIDO** para **CADA ARQUIVO PHP** que foi modificado, no formato **ESTRITO**:
+
+    --- START OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+    <?php // Código PHP completo e corrigido do arquivo... ?>
+    --- END OF FILE path/relativo/ao/projeto/arquivo_corrigido.php ---
+    --- START OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+    <?php // Código PHP completo e corrigido do outro arquivo... ?>
+    --- END OF FILE path/relativo/ao/projeto/outro_arquivo_corrigido.php ---
+
+    *   Use o caminho exato do arquivo original nos marcadores.
+    *   Inclua o código **COMPLETO** do arquivo modificado.
+    *   **NENHUM** texto extra (introdução, explicação, etc.) fora dos blocos `--- START/END ---`.
+    *   Comece diretamente com o primeiro `--- START OF FILE ...`. Termine imediatamente após o último `--- END OF FILE ...`.
+9.  **SE NENHUMA CORREÇÃO FOR NECESSÁRIA:** Se concluir que os erros no `phpstan_analysis.txt` não exigem mudanças nos arquivos de código fornecidos, sua resposta **DEVE SER ABSOLUTAMENTE VAZIA** (string vazia).
+
+**OBSERVAÇÃO ADICIONAL PRIORITÁRIA:**
+__OBSERVACAO_ADICIONAL__
+
+Execute a tarefa seguindo **TODAS** estas regras com **MÁXIMA FIDELIDADE**.


### PR DESCRIPTION
… das tasks fix-phpstan, fix-artisan-test e fix-artisan-dusk

Adiciona os arquivos de template necessários para as futuras tasks `fix-phpstan`, `fix-artisan-test` e `fix-artisan-dusk` no script `llm_interact.py`.

Inclui:
- Template seletor de contexto (`templates/context_selectors/`).
- Meta-prompt (`templates/meta-prompts/`).
- Prompt final (`templates/prompts/`).

Estes arquivos suportam a funcionalidade de seleção de contexto introduzida na Issue #38, preparando a infraestrutura para que a LLM possa auxiliar na correção de erros do PHPStan.