### PR TITLE
feat(auth): Implementa lógica de registro local com validação Replicado e atribuição de roles (#25)

### DIFF
--- a/app/Exceptions/ReplicadoServiceException.php
+++ b/app/Exceptions/ReplicadoServiceException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+/**
+ * Custom exception for errors originating from the ReplicadoService.
+ */
+class ReplicadoServiceException extends Exception
+{
+    // You can add custom properties or methods to this exception if needed in the future.
+    // For example, a constructor that accepts a specific error code or context.
+}

--- a/app/Exceptions/ReplicadoServiceException.php
+++ b/app/Exceptions/ReplicadoServiceException.php
@@ -5,10 +5,10 @@ namespace App\Exceptions;
 use Exception;
 
 /**
- * Custom exception for errors originating from the ReplicadoService.
- */
+* Exceção customizada para erros originados no ReplicadoService.
+*/
 class ReplicadoServiceException extends Exception
 {
-    // You can add custom properties or methods to this exception if needed in the future.
-    // For example, a constructor that accepts a specific error code or context.
+// You can add custom properties or methods to this exception if needed in the future.
+// For example, a constructor that accepts a specific error code or context.
 }

--- a/app/Exceptions/ReplicadoServiceException.php
+++ b/app/Exceptions/ReplicadoServiceException.php
@@ -5,10 +5,10 @@ namespace App\Exceptions;
 use Exception;
 
 /**
-* Exceção customizada para erros originados no ReplicadoService.
-*/
+ * Exceção customizada para erros originados no ReplicadoService.
+ */
 class ReplicadoServiceException extends Exception
 {
-// You can add custom properties or methods to this exception if needed in the future.
-// For example, a constructor that accepts a specific error code or context.
+    // You can add custom properties or methods to this exception if needed in the future.
+    // For example, a constructor that accepts a specific error code or context.
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,12 +21,12 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Password::defaults(function () {
-            $rule = Password::min(8); 
+            $rule = Password::min(8);
 
             return $rule->letters()
-                        ->mixedCase()
-                        ->numbers()
-                        ->symbols();
+                ->mixedCase()
+                ->numbers()
+                ->symbols();
         });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Validation\Rules\Password;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Password::defaults(function () {
+            $rule = Password::min(8); 
+
+            return $rule->letters()
+                        ->mixedCase()
+                        ->numbers()
+                        ->symbols();
+        });
     }
 }

--- a/app/Services/ReplicadoService.php
+++ b/app/Services/ReplicadoService.php
@@ -1,4 +1,3 @@
-
 <?php
 
 namespace App\Services;

--- a/app/Services/ReplicadoService.php
+++ b/app/Services/ReplicadoService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Log; // Assuming Uspdev\Replicado is used
+use Uspdev\Replicado\Pessoa; // For logging errors
+
+/**
+ * Service class to interact with USP's Replicado database.
+ *
+ * NOTE: This is a placeholder structure. The actual implementation depends
+ * on the 'uspdev/replicado' package or direct DB connection setup.
+ */
+class ReplicadoService
+{
+    /**
+     * Validates if the provided USP Number (codpes) and email belong to the same valid person in Replicado.
+     *
+     * This method needs to be implemented based on the available Replicado data access strategy.
+     * It should check if the codpes exists and if the provided email is associated with that codpes.
+     *
+     * @param  int  $codpes  The USP number (NUSP).
+     * @param  string  $email  The email address to validate against the codpes.
+     * @return bool Returns true if the codpes and email match a valid person, false otherwise.
+     *
+     * @throws \Exception If there's an issue communicating with the Replicado database.
+     */
+    public function validarNuspEmail(int $codpes, string $email): bool
+    {
+        // --- Placeholder Implementation ---
+        // This requires the actual logic using uspdev/replicado or similar.
+
+        // Basic check: Ensure email is a USP email if we are validating
+        // This might be redundant if already checked elsewhere, but adds safety.
+        if (! str_ends_with(strtolower($email), 'usp.br')) {
+            Log::warning("Replicado Validation: Attempt to validate non-USP email '{$email}' for codpes {$codpes}.");
+            // return false; // Or handle as per requirements, maybe this check is done earlier.
+        }
+
+        try {
+            // Example using uspdev/replicado (adjust based on actual package methods)
+            $emailsPessoa = Pessoa::emails($codpes); // Get all emails associated with codpes
+
+            if (empty($emailsPessoa)) {
+                Log::info("Replicado Validation: No person found for codpes {$codpes}.");
+
+                return false; // Person (codpes) doesn't exist or has no emails registered.
+            }
+
+            // Check if the provided email is in the list of the person's emails
+            foreach ($emailsPessoa as $emailCadastrado) {
+                if (is_string($emailCadastrado) && (strtolower(trim($emailCadastrado)) === strtolower($email))) {
+                    Log::info("Replicado Validation: Success for codpes {$codpes} and email '{$email}'.");
+
+                    return true; // Found a match
+                }
+            }
+
+            // If loop completes without finding a matchs
+            Log::info("Replicado Validation: Email '{$email}' does not match registered emails for codpes {$codpes}.");
+
+            return false;
+
+            /*
+            // Alternative hypothetical direct query logic (if not using the package)
+            $result = DB::connection('replicado') // Assuming a 'replicado' connection exists
+                ->table('PESSOA') // Replace with actual table names
+                ->join('EMAILPESSOA', 'PESSOA.codpes', '=', 'EMAILPESSOA.codpes')
+                ->where('PESSOA.codpes', $codpes)
+                ->where('EMAILPESSOA.codema', $email)
+                // Add conditions to check for active status if necessary
+                ->exists();
+
+            return $result;
+            */
+
+        } catch (\Exception $e) {
+            // Log the error for investigation
+            Log::error("Replicado Service Error: Failed validating codpes {$codpes} and email '{$email}'. Error: ".$e->getMessage());
+
+            // Re-throw the exception to be handled by the caller (e.g., the validation rule)
+            // This allows the caller to decide how to handle service failures (e.g., show specific error).
+            throw new \Exception('Replicado service communication error.', 0, $e);
+        }
+
+        // Default to false if something unexpected happens, though exceptions should be caught.
+        // return false; // This line might be unreachable if exceptions are always thrown/caught.
+    }
+
+    // Add other methods to interact with Replicado as needed...
+}

--- a/app/Services/ReplicadoService.php
+++ b/app/Services/ReplicadoService.php
@@ -1,3 +1,4 @@
+
 <?php
 
 namespace App\Services;
@@ -7,55 +8,55 @@ use Illuminate\Support\Facades\Log;
 use Uspdev\Replicado\Pessoa;
 
 /**
- * Service class to interact with USP's Replicado database.
- */
+* Classe de serviço para interagir com o banco de dados Replicado da USP.
+*/
 class ReplicadoService
 {
-    /**
-     * Validates if the provided USP Number (codpes) and email belong to the same valid person in Replicado.
-     *
-     * This method needs to be implemented based on the available Replicado data access strategy.
-     * It should check if the codpes exists and if the provided email is associated with that codpes.
-     *
-     * @param  int  $codpes  The USP number (NUSP).
-     * @param  string  $email  The email address to validate against the codpes.
-     * @return bool Returns true if the codpes and email match a valid person, false otherwise.
-     *
-     * @throws \App\Exceptions\ReplicadoServiceException If there's an issue communicating with the Replicado database.
-     */
-    public function validarNuspEmail(int $codpes, string $email): bool
-    {
-        if (! str_ends_with(strtolower($email), 'usp.br')) {
-            Log::warning("Replicado Validation: Attempt to validate non-USP email '{$email}' for codpes {$codpes}.");
-            // Depending on strictness, this might be an early return false or even an exception.
-            // For now, let it proceed to check against Replicado records.
-        }
+/**
+* Valida se o Número USP (codpes) e o e-mail fornecidos pertencem à mesma pessoa válida no Replicado.
+*
+* Este método consulta o Replicado para verificar a existência do `codpes`
+* e se o `email` fornecido está associado a esse `codpes`.
+*
+* @param int $codpes O Número USP (NUSP).
+* @param string $email O endereço de e-mail para validar em conjunto com o `codpes`.
+* @return bool Retorna `true` se o `codpes` e o `email` corresponderem a uma pessoa válida, `false` caso contrário.
+*
+* @throws \App\Exceptions\ReplicadoServiceException Se ocorrer um problema de comunicação com o banco de dados Replicado.
+*/
+public function validarNuspEmail(int $codpes, string $email): bool
+{
+if (! str_ends_with(strtolower($email), 'usp.br')) {
+Log::warning("Replicado Validation: Attempt to validate non-USP email '{$email}' for codpes {$codpes}.");
+// Depending on strictness, this might be an early return false or even an exception.
+// For now, let it proceed to check against Replicado records.
+}
 
-        try {
-            $emailsPessoa = Pessoa::emails($codpes);
+try {
+$emailsPessoa = Pessoa::emails($codpes);
 
-            if (empty($emailsPessoa)) {
-                Log::info("Replicado Validation: No person found or no emails registered for codpes {$codpes}.");
+if (empty($emailsPessoa)) {
+Log::info("Replicado Validation: No person found or no emails registered for codpes {$codpes}.");
 
-                return false;
-            }
+return false;
+}
 
-            foreach ($emailsPessoa as $emailCadastrado) {
-                if (is_string($emailCadastrado) && (strtolower(trim($emailCadastrado)) === strtolower($email))) {
-                    Log::info("Replicado Validation: Success for codpes {$codpes} and email '{$email}'.");
+foreach ($emailsPessoa as $emailCadastrado) {
+if (is_string($emailCadastrado) && (strtolower(trim($emailCadastrado)) === strtolower($email))) {
+Log::info("Replicado Validation: Success for codpes {$codpes} and email '{$email}'.");
 
-                    return true;
-                }
-            }
+return true;
+}
+}
 
-            Log::info("Replicado Validation: Email '{$email}' does not match registered emails for codpes {$codpes}.");
+Log::info("Replicado Validation: Email '{$email}' does not match registered emails for codpes {$codpes}.");
 
-            return false;
+return false;
 
-        } catch (\Exception $e) {
-            Log::error("Replicado Service Error: Failed validating codpes {$codpes} and email '{$email}'. Error: ".$e->getMessage(), ['exception' => $e]);
-            // Re-throw as a custom, more specific exception for better handling by callers.
-            throw new ReplicadoServiceException('Replicado service communication error while validating NUSP/email.', 0, $e);
-        }
-    }
+} catch (\Exception $e) {
+Log::error("Replicado Service Error: Failed validating codpes {$codpes} and email '{$email}'. Error: ".$e->getMessage(), ['exception' => $e]);
+// Re-throw as a custom, more specific exception for better handling by callers.
+throw new ReplicadoServiceException('Replicado service communication error while validating NUSP/email.', 0, $e);
+}
+}
 }

--- a/app/Services/ReplicadoService.php
+++ b/app/Services/ReplicadoService.php
@@ -8,55 +8,55 @@ use Illuminate\Support\Facades\Log;
 use Uspdev\Replicado\Pessoa;
 
 /**
-* Classe de serviço para interagir com o banco de dados Replicado da USP.
-*/
+ * Classe de serviço para interagir com o banco de dados Replicado da USP.
+ */
 class ReplicadoService
 {
-/**
-* Valida se o Número USP (codpes) e o e-mail fornecidos pertencem à mesma pessoa válida no Replicado.
-*
-* Este método consulta o Replicado para verificar a existência do `codpes`
-* e se o `email` fornecido está associado a esse `codpes`.
-*
-* @param int $codpes O Número USP (NUSP).
-* @param string $email O endereço de e-mail para validar em conjunto com o `codpes`.
-* @return bool Retorna `true` se o `codpes` e o `email` corresponderem a uma pessoa válida, `false` caso contrário.
-*
-* @throws \App\Exceptions\ReplicadoServiceException Se ocorrer um problema de comunicação com o banco de dados Replicado.
-*/
-public function validarNuspEmail(int $codpes, string $email): bool
-{
-if (! str_ends_with(strtolower($email), 'usp.br')) {
-Log::warning("Replicado Validation: Attempt to validate non-USP email '{$email}' for codpes {$codpes}.");
-// Depending on strictness, this might be an early return false or even an exception.
-// For now, let it proceed to check against Replicado records.
-}
+    /**
+     * Valida se o Número USP (codpes) e o e-mail fornecidos pertencem à mesma pessoa válida no Replicado.
+     *
+     * Este método consulta o Replicado para verificar a existência do `codpes`
+     * e se o `email` fornecido está associado a esse `codpes`.
+     *
+     * @param  int  $codpes  O Número USP (NUSP).
+     * @param  string  $email  O endereço de e-mail para validar em conjunto com o `codpes`.
+     * @return bool Retorna `true` se o `codpes` e o `email` corresponderem a uma pessoa válida, `false` caso contrário.
+     *
+     * @throws \App\Exceptions\ReplicadoServiceException Se ocorrer um problema de comunicação com o banco de dados Replicado.
+     */
+    public function validarNuspEmail(int $codpes, string $email): bool
+    {
+        if (! str_ends_with(strtolower($email), 'usp.br')) {
+            Log::warning("Replicado Validation: Attempt to validate non-USP email '{$email}' for codpes {$codpes}.");
+            // Depending on strictness, this might be an early return false or even an exception.
+            // For now, let it proceed to check against Replicado records.
+        }
 
-try {
-$emailsPessoa = Pessoa::emails($codpes);
+        try {
+            $emailsPessoa = Pessoa::emails($codpes);
 
-if (empty($emailsPessoa)) {
-Log::info("Replicado Validation: No person found or no emails registered for codpes {$codpes}.");
+            if (empty($emailsPessoa)) {
+                Log::info("Replicado Validation: No person found or no emails registered for codpes {$codpes}.");
 
-return false;
-}
+                return false;
+            }
 
-foreach ($emailsPessoa as $emailCadastrado) {
-if (is_string($emailCadastrado) && (strtolower(trim($emailCadastrado)) === strtolower($email))) {
-Log::info("Replicado Validation: Success for codpes {$codpes} and email '{$email}'.");
+            foreach ($emailsPessoa as $emailCadastrado) {
+                if (is_string($emailCadastrado) && (strtolower(trim($emailCadastrado)) === strtolower($email))) {
+                    Log::info("Replicado Validation: Success for codpes {$codpes} and email '{$email}'.");
 
-return true;
-}
-}
+                    return true;
+                }
+            }
 
-Log::info("Replicado Validation: Email '{$email}' does not match registered emails for codpes {$codpes}.");
+            Log::info("Replicado Validation: Email '{$email}' does not match registered emails for codpes {$codpes}.");
 
-return false;
+            return false;
 
-} catch (\Exception $e) {
-Log::error("Replicado Service Error: Failed validating codpes {$codpes} and email '{$email}'. Error: ".$e->getMessage(), ['exception' => $e]);
-// Re-throw as a custom, more specific exception for better handling by callers.
-throw new ReplicadoServiceException('Replicado service communication error while validating NUSP/email.', 0, $e);
-}
-}
+        } catch (\Exception $e) {
+            Log::error("Replicado Service Error: Failed validating codpes {$codpes} and email '{$email}'. Error: ".$e->getMessage(), ['exception' => $e]);
+            // Re-throw as a custom, more specific exception for better handling by callers.
+            throw new ReplicadoServiceException('Replicado service communication error while validating NUSP/email.', 0, $e);
+        }
+    }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,11 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        // Call other seeders
+        $this->call([
+            RoleSeeder::class,
+            // Other seeders can be added here
+        ]);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
@@ -8,31 +7,27 @@ use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
 /**
-*
-*Seeder para popular a tabela de roles com os papéis padrão da aplicação.
-*/
+ *Seeder para popular a tabela de roles com os papéis padrão da aplicação.
+ */
 class RoleSeeder extends Seeder
 {
-/**
-*
-*Executa o seeder para o banco de dados.
-*
-*Cria os papéis (roles) padrão 'usp_user' e 'external_user' para o guard 'web'.
-*
-*Limpa o cache de permissões antes de criar os papéis para garantir consistência.
-*
-*@return void
-*/
-public function run(): void
-{
-// Reset cached roles and permissions
-app()[PermissionRegistrar::class]->forgetCachedPermissions();
+    /**
+     *Executa o seeder para o banco de dados.
+     *
+     *Cria os papéis (roles) padrão 'usp_user' e 'external_user' para o guard 'web'.
+     *
+     *Limpa o cache de permissões antes de criar os papéis para garantir consistência.
+     */
+    public function run(): void
+    {
+        // Reset cached roles and permissions
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
-// Create roles for local authentication
-Role::firstOrCreate(['name' => 'usp_user', 'guard_name' => 'web']);
-Role::firstOrCreate(['name' => 'external_user', 'guard_name' => 'web']);
+        // Create roles for local authentication
+        Role::firstOrCreate(['name' => 'usp_user', 'guard_name' => 'web']);
+        Role::firstOrCreate(['name' => 'external_user', 'guard_name' => 'web']);
 
-// Add other roles if needed, for example:
-// Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
-}
+        // Add other roles if needed, for example:
+        // Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
+    }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,28 +1,38 @@
 <?php
 
+
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
+/**
+*
+*Seeder para popular a tabela de roles com os papéis padrão da aplicação.
+*/
 class RoleSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * Creates the default roles for the application.
-     */
-    public function run(): void
-    {
-        // Reset cached roles and permissions
-        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+/**
+*
+*Executa o seeder para o banco de dados.
+*
+*Cria os papéis (roles) padrão 'usp_user' e 'external_user' para o guard 'web'.
+*
+*Limpa o cache de permissões antes de criar os papéis para garantir consistência.
+*
+*@return void
+*/
+public function run(): void
+{
+// Reset cached roles and permissions
+app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
-        // Create roles for local authentication
-        Role::firstOrCreate(['name' => 'usp_user', 'guard_name' => 'web']);
-        Role::firstOrCreate(['name' => 'external_user', 'guard_name' => 'web']);
+// Create roles for local authentication
+Role::firstOrCreate(['name' => 'usp_user', 'guard_name' => 'web']);
+Role::firstOrCreate(['name' => 'external_user', 'guard_name' => 'web']);
 
-        // Add other roles if needed, for example:
-        // Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
-    }
+// Add other roles if needed, for example:
+// Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
+}
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * Creates the default roles for the application.
+     */
+    public function run(): void
+    {
+        // Reset cached roles and permissions
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
+
+        // Create roles for local authentication
+        Role::firstOrCreate(['name' => 'usp_user', 'guard_name' => 'web']);
+        Role::firstOrCreate(['name' => 'external_user', 'guard_name' => 'web']);
+
+        // Add other roles if needed, for example:
+        // Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
+    }
+}

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -187,7 +187,7 @@ return [
         'display_type' => 'display type',
         'district' => 'district',
         'duration' => 'duration',
-        'email' => 'email',
+        'email' => 'email address', // Adjusted for clarity
         'excerpt' => 'excerpt',
         'filter' => 'filter',
         'finished_at' => 'finished at',
@@ -278,5 +278,9 @@ return [
         'winner' => 'winner',
         'work' => 'work',
         'year' => 'year',
+        // --- ADDED ---
+        'codpes' => 'USP Number (codpes)',
+        'sou_da_usp' => 'I\'m from USP',
+        // --- END ADDED ---
     ],
 ];

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -152,6 +152,41 @@ return [
     'uppercase' => 'The :attribute field must be uppercase.',
     'url' => 'The :attribute field must be a valid URL.',
     'uuid' => 'The :attribute field must be a valid UUID.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+        // --- ADDED FOR AC3/AC4 ---
+        'codpes' => [
+            'replicado_validation_failed' => 'The USP Number and Email combination is invalid according to USP records.',
+            'replicado_service_unavailable' => 'Could not verify USP credentials at this time. Please try again later.',
+        ],
+        // --- END ADDED ---
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
     'attributes' => [
         'address' => 'address',
         'affiliate_url' => 'affiliate URL',

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -168,10 +168,10 @@ return [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
-        // --- ADDED FOR AC3/AC4 ---
+        // --- ADDED FOR AC3/AC4/AC5 ---
         'codpes' => [
-            'replicado_validation_failed' => 'The USP Number and Email combination is invalid according to USP records.',
-            'replicado_service_unavailable' => 'Could not verify USP credentials at this time. Please try again later.',
+            'replicado_validation_failed' => 'The USP Number and Email combination is invalid according to USP records.', // AC4 Message
+            'replicado_service_unavailable' => 'Could not verify USP credentials at this time. Please try again later.', // AC5 Message
         ],
         // --- END ADDED ---
     ],

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -168,12 +168,10 @@ return [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
-        // --- ADDED FOR AC3/AC4/AC5 ---
-        'codpes' => [
-            'replicado_validation_failed' => 'The USP Number and Email combination is invalid according to USP records.', // AC4 Message
-            'replicado_service_unavailable' => 'Could not verify USP credentials at this time. Please try again later.', // AC5 Message
+        'codpes' => [ // Changed to match 'codpes.replicado_validation_failed' structure
+            'replicado_validation_failed' => 'The USP Number and Email combination is invalid according to USP records.',
+            'replicado_service_unavailable' => 'Could not verify USP credentials at this time. Please try again later.',
         ],
-        // --- END ADDED ---
     ],
 
     /*
@@ -222,7 +220,7 @@ return [
         'display_type' => 'display type',
         'district' => 'district',
         'duration' => 'duration',
-        'email' => 'email address', // Adjusted for clarity
+        'email' => 'email address',
         'excerpt' => 'excerpt',
         'filter' => 'filter',
         'finished_at' => 'finished at',
@@ -313,9 +311,7 @@ return [
         'winner' => 'winner',
         'work' => 'work',
         'year' => 'year',
-        // --- ADDED ---
         'codpes' => 'USP Number (codpes)',
         'sou_da_usp' => 'I\'m from USP',
-        // --- END ADDED ---
     ],
 ];

--- a/lang/pt_BR/validation.php
+++ b/lang/pt_BR/validation.php
@@ -278,5 +278,9 @@ return [
         'winner' => 'ganhador',
         'work' => 'trabalho',
         'year' => 'ano',
+        // --- ADDED ---
+        'codpes' => 'Número USP', // Adjusted translation
+        'sou_da_usp' => 'Sou da USP',
+        // --- END ADDED ---
     ],
 ];

--- a/lang/pt_BR/validation.php
+++ b/lang/pt_BR/validation.php
@@ -168,12 +168,10 @@ return [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
-        // --- ADDED FOR AC3/AC4/AC5 ---
-        'codpes' => [
-            'replicado_validation_failed' => 'A combinação de Número USP e Email é inválida nos registros da USP.', // AC4 Message
-            'replicado_service_unavailable' => 'Não foi possível verificar as credenciais USP neste momento. Por favor, tente novamente mais tarde.', // AC5 Message
+        'codpes' => [ // Changed to match 'codpes.replicado_validation_failed' structure
+            'replicado_validation_failed' => 'A combinação de Número USP e Email é inválida nos registros da USP.',
+            'replicado_service_unavailable' => 'Não foi possível verificar as credenciais USP neste momento. Por favor, tente novamente mais tarde.',
         ],
-        // --- END ADDED ---
     ],
 
     /*
@@ -313,9 +311,7 @@ return [
         'winner' => 'ganhador',
         'work' => 'trabalho',
         'year' => 'ano',
-        // --- ADDED ---
-        'codpes' => 'Número USP', // Adjusted translation
+        'codpes' => 'Número USP (codpes)',
         'sou_da_usp' => 'Sou da USP',
-        // --- END ADDED ---
     ],
 ];

--- a/lang/pt_BR/validation.php
+++ b/lang/pt_BR/validation.php
@@ -168,10 +168,10 @@ return [
         'attribute-name' => [
             'rule-name' => 'custom-message',
         ],
-        // --- ADDED FOR AC3/AC4 ---
+        // --- ADDED FOR AC3/AC4/AC5 ---
         'codpes' => [
-            'replicado_validation_failed' => 'A combinação de Número USP e Email é inválida nos registros da USP.',
-            'replicado_service_unavailable' => 'Não foi possível verificar as credenciais USP neste momento. Por favor, tente novamente mais tarde.',
+            'replicado_validation_failed' => 'A combinação de Número USP e Email é inválida nos registros da USP.', // AC4 Message
+            'replicado_service_unavailable' => 'Não foi possível verificar as credenciais USP neste momento. Por favor, tente novamente mais tarde.', // AC5 Message
         ],
         // --- END ADDED ---
     ],

--- a/lang/pt_BR/validation.php
+++ b/lang/pt_BR/validation.php
@@ -152,6 +152,41 @@ return [
     'uppercase' => 'O :attribute deve ser maiúsculo.',
     'url' => 'O formato da URL informada para o campo :attribute é inválido.',
     'uuid' => 'O campo :attribute deve ser um UUID válido.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+        // --- ADDED FOR AC3/AC4 ---
+        'codpes' => [
+            'replicado_validation_failed' => 'A combinação de Número USP e Email é inválida nos registros da USP.',
+            'replicado_service_unavailable' => 'Não foi possível verificar as credenciais USP neste momento. Por favor, tente novamente mais tarde.',
+        ],
+        // --- END ADDED ---
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
     'attributes' => [
         'address' => 'endereço',
         'affiliate_url' => 'URL de afiliado',

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -48,7 +48,7 @@ new #[Layout('layouts.guest')] class extends Component
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             // --- ADDED/MODIFIED VALIDATION ---
-            'sou_da_usp' => ['boolean'], // Validate the checkbox value itself
+            //'sou_da_usp' => ['boolean'], // Validate the checkbox value itself
             'codpes' => [
                 // Only require codpes if the sou_da_usp checkbox is checked
                 // (which is automatically checked if email ends with @usp.br)

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -64,7 +64,7 @@ new #[Layout('layouts.guest')] class extends Component
                         $replicadoService = app(ReplicadoService::class);
                         try {
                             if (!$replicadoService->validarNuspEmail((int)$value, $this->email)) {
-                                // AC4 preparation: Use a specific key for the failure message
+                                // AC4: Fail validation with specific message if Replicado validation fails
                                 $fail('validation.custom.replicado_validation_failed');
                             }
                         } catch (\Exception $e) {

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -12,194 +12,227 @@ use Illuminate\Validation\Rules;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
+/**
+* Componente Livewire/Volt para a página de registro de usuários.
+*
+* Gerencia o formulário de registro, incluindo a lógica condicional para usuários USP
+* com validação de Número USP (codpes) e e-mail via ReplicadoService.
+*/
 new #[Layout('layouts.guest')] class extends Component
 {
-    public string $name = '';
-    public string $email = '';
-    public string $password = '';
-    public string $password_confirmation = '';
+/** @var string O nome completo do usuário. */
+public string $name = '';
 
-    public bool $sou_da_usp = false;
-    public string $codpes = '';
+/** @var string O endereço de e-mail do usuário. */
+public string $email = '';
 
-    /**
-     * Automatically check "Sou da USP" if email ends with usp.br
-     */
-    public function updatedEmail(string $value): void
-    {
-        if (str_ends_with(strtolower($value), 'usp.br')) {
-            $this->sou_da_usp = true;
-        }
-    }
+/** @var string A senha escolhida pelo usuário. */
+public string $password = '';
 
-    /**
-     * Validation rules.
-     */
-    public function rules(): array
-    {
-        return [
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
-            'sou_da_usp' => ['boolean'],
-            'codpes' => [
-                Rule::requiredIf($this->sou_da_usp),
-                'nullable',
-                'numeric',
-                'digits_between:6,8',
-                function (string $attribute, mixed $value, Closure $fail) {
-                    if ($this->sou_da_usp && !empty($value)) {
-                        $replicadoService = app(ReplicadoService::class);
-                        try {
-                            if (!$replicadoService->validarNuspEmail((int)$value, $this->email)) {
-                                // AC4: Fail validation if Replicado validation returns false
-                                $fail('validation.custom.codpes.replicado_validation_failed');
-                            }
-                        } catch (ReplicadoServiceException $e) { // Catch specific exception
-                            // AC5: Handle Replicado service communication failure.
-                            // Logging is already done within ReplicadoService.
-                            // Return a generic validation error message to the user.
-                            $fail('validation.custom.codpes.replicado_service_unavailable');
-                        } catch (\Exception $e) {
-                            // Catch any other unexpected exceptions from the service call
-                            Log::error('Unexpected error during Replicado validation: '.$e->getMessage(), ['exception' => $e]);
-                            $fail('validation.custom.codpes.replicado_service_unavailable'); // Still show a generic error to user
-                        }
-                    }
-                },
-            ],
-            'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
-        ];
-    }
+/** @var string A confirmação da senha. */
+public string $password_confirmation = '';
+
+/** @var bool Indica se o usuário se declara como membro da USP. */
+public bool $sou_da_usp = false;
+
+/** @var string O Número USP (codpes) do usuário, se aplicável. */
+public string $codpes = '';
+
+/**
+* Hook executado quando a propriedade `$email` é atualizada.
+*
+* Marca automaticamente o checkbox "Sou da USP" se o e-mail terminar com `usp.br`.
+*
+* @param string $value O novo valor do e-mail.
+* @return void
+*/
+public function updatedEmail(string $value): void
+{
+if (str_ends_with(strtolower($value), 'usp.br')) {
+$this->sou_da_usp = true;
+}
+}
+
+/**
+* Define as regras de validação para o formulário de registro.
+*
+* @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+*/
+public function rules(): array
+{
+return [
+'name' => ['required', 'string', 'max:255'],
+'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+'sou_da_usp' => ['boolean'],
+'codpes' => [
+Rule::requiredIf($this->sou_da_usp),
+'nullable',
+'numeric',
+'digits_between:6,8',
+function (string $attribute, mixed $value, Closure $fail) {
+if ($this->sou_da_usp && !empty($value)) {
+$replicadoService = app(ReplicadoService::class);
+try {
+if (!$replicadoService->validarNuspEmail((int)$value, $this->email)) {
+// AC4: Fail validation if Replicado validation returns false
+$fail('validation.custom.codpes.replicado_validation_failed');
+}
+} catch (ReplicadoServiceException $e) { // Catch specific exception
+// AC5: Handle Replicado service communication failure.
+// Logging is already done within ReplicadoService.
+// Return a generic validation error message to the user.
+$fail('validation.custom.codpes.replicado_service_unavailable');
+} catch (\Exception $e) {
+// Catch any other unexpected exceptions from the service call
+Log::error('Unexpected error during Replicado validation: '.$e->getMessage(), ['exception' => $e]);
+$fail('validation.custom.codpes.replicado_service_unavailable'); // Still show a generic error to user
+}
+}
+},
+],
+'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
+];
+}
 
 
-    /**
-     * Handle an incoming registration request.
-     */
-    public function register(): void
-    {
-        $validated = $this->validate();
+/**
+* Processa a submissão do formulário de registro.
+*
+* Valida os dados, cria o usuário, atribui o role apropriado (usp_user ou external_user),
+* dispara o evento Registered, realiza o login e redireciona para o dashboard.
+*
+* @return void
+*
+* @throws \Illuminate\Validation\ValidationException
+*/
+public function register(): void
+{
+$validated = $this->validate();
 
-        $userData = [
-            'name' => $validated['name'],
-            'email' => $validated['email'],
-            'password' => Hash::make($validated['password']),
-            'codpes' => ($this->sou_da_usp && isset($validated['codpes'])) ? $validated['codpes'] : null,
-        ];
+$userData = [
+'name' => $validated['name'],
+'email' => $validated['email'],
+'password' => Hash::make($validated['password']),
+'codpes' => ($this->sou_da_usp && isset($validated['codpes'])) ? $validated['codpes'] : null,
+];
 
-        $user = User::create($userData);
+$user = User::create($userData);
 
-        // Assign role based on whether codpes was successfully validated and stored
-        if ($user->codpes !== null) {
-            // This implies $this->sou_da_usp was true, codpes was provided,
-            // and Replicado validation was successful.
-            $user->assignRole('usp_user'); // AC7
-        } else {
-            // This covers:
-            // 1. User is not from USP ($this->sou_da_usp was false).
-            // 2. User claimed to be from USP, but Replicado validation failed (mismatch or service error).
-            $user->assignRole('external_user'); // AC8
-        }
+// Assign role based on whether codpes was successfully validated and stored
+if ($user->codpes !== null) {
+// This implies $this->sou_da_usp was true, codpes was provided,
+// and Replicado validation was successful.
+$user->assignRole('usp_user'); // AC7
+} else {
+// This covers:
+// 1. User is not from USP ($this->sou_da_usp was false).
+// 2. User claimed to be from USP, but Replicado validation failed (mismatch or service error).
+$user->assignRole('external_user'); // AC8
+}
 
-        event(new Registered($user));
+event(new Registered($user));
 
-        Auth::login($user);
+Auth::login($user);
 
-        $this->redirect(route('dashboard', absolute: false), navigate: true);
-    }
+$this->redirect(route('dashboard', absolute: false), navigate: true);
+}
 }; ?>
+
 
 {{-- Wrap the interactive section with x-data --}}
 {{-- No extra Alpine state needed if Livewire handles it --}}
+
 <div x-data="{}">
-    <div class="flex justify-center mb-4">
-        <a href="/" wire:navigate>
-            <img src="{{ Vite::asset('resources/images/ime/logo-vertical-simplificada-padrao.png') }}" alt="Logo IME-USP" class="w-20 h-auto block dark:hidden" dusk="ime-logo-light">
-            <img src="{{ Vite::asset('resources/images/ime/logo-vertical-simplificada-branca.png') }}" alt="Logo IME-USP" class="w-20 h-auto hidden dark:block" dusk="ime-logo-dark">
-        </a>
+<div class="flex justify-center mb-4">
+<a href="/" wire:navigate>
+<img src="{{ Vite::asset('resources/images/ime/logo-vertical-simplificada-padrao.png') }}" alt="Logo IME-USP" class="w-20 h-auto block dark:hidden" dusk="ime-logo-light">
+<img src="{{ Vite::asset('resources/images/ime/logo-vertical-simplificada-branca.png') }}" alt="Logo IME-USP" class="w-20 h-auto hidden dark:block" dusk="ime-logo-dark">
+</a>
+</div>
+
+<form wire:submit="register">
+    <!-- Name -->
+    <div>
+        <x-input-label for="name" :value="__('Name')" dusk="name-label" />
+        <x-text-input wire:model="name" id="name" class="block mt-1 w-full" type="text" name="name" required autofocus autocomplete="name" dusk="name-input" />
+        <x-input-error :messages="$errors->get('name')" class="mt-2" dusk="name-error" />
     </div>
 
-    <form wire:submit="register">
-        <!-- Name -->
-        <div>
-            <x-input-label for="name" :value="__('Name')" dusk="name-label" />
-            <x-text-input wire:model="name" id="name" class="block mt-1 w-full" type="text" name="name" required autofocus autocomplete="name" dusk="name-input" />
-            <x-input-error :messages="$errors->get('name')" class="mt-2" dusk="name-error" />
-        </div>
+    <!-- Email Address -->
+    <div class="mt-4">
+        <x-input-label for="email" :value="__('Email')" dusk="email-label" />
+        {{-- Use wire:model.blur to update Livewire state less frequently --}}
+        <x-text-input wire:model.blur="email" id="email" class="block mt-1 w-full" type="email" name="email" required autocomplete="username" dusk="email-input" />
+        <x-input-error :messages="$errors->get('email')" class="mt-2" dusk="email-error" />
+    </div>
 
-        <!-- Email Address -->
-        <div class="mt-4">
-            <x-input-label for="email" :value="__('Email')" dusk="email-label" />
-            {{-- Use wire:model.blur to update Livewire state less frequently --}}
-            <x-text-input wire:model.blur="email" id="email" class="block mt-1 w-full" type="email" name="email" required autocomplete="username" dusk="email-input" />
-            <x-input-error :messages="$errors->get('email')" class="mt-2" dusk="email-error" />
-        </div>
+    {{-- --- ADDED USP FIELDS --- --}}
+    <!-- "Sou da USP" Checkbox -->
+    <div class="block mt-4">
+        <label for="sou_da_usp" class="inline-flex items-center">
+            {{-- AC13: Uses existing dusk selector 'is-usp-user-checkbox' from previous commit --}}
+            <input wire:model.live="sou_da_usp" {{-- Use .live for immediate conditional logic --}}
+                   id="sou_da_usp"
+                   type="checkbox"
+                   {{-- Disable checkbox if email is already a USP email --}}
+                   :disabled="$wire.email.toLowerCase().endsWith('usp.br')"
+                   class="rounded dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                   name="sou_da_usp"
+                   dusk="is-usp-user-checkbox">
+            <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">{{ __('I\'m from USP') }}</span>
+        </label>
+         <x-input-error :messages="$errors->get('sou_da_usp')" class="mt-2" dusk="sou_da_usp-error" />
+    </div>
 
-        {{-- --- ADDED USP FIELDS --- --}}
-        <!-- "Sou da USP" Checkbox -->
-        <div class="block mt-4">
-            <label for="sou_da_usp" class="inline-flex items-center">
-                {{-- AC13: Uses existing dusk selector 'is-usp-user-checkbox' from previous commit --}}
-                <input wire:model.live="sou_da_usp" {{-- Use .live for immediate conditional logic --}}
-                       id="sou_da_usp"
-                       type="checkbox"
-                       {{-- Disable checkbox if email is already a USP email --}}
-                       :disabled="$wire.email.toLowerCase().endsWith('usp.br')"
-                       class="rounded dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
-                       name="sou_da_usp"
-                       dusk="is-usp-user-checkbox">
-                <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">{{ __('I\'m from USP') }}</span>
-            </label>
-             <x-input-error :messages="$errors->get('sou_da_usp')" class="mt-2" dusk="sou_da_usp-error" />
-        </div>
-
-        <!-- Número USP (codpes) Field - Conditional -->
-        {{-- Show if email ends with @usp.br OR the checkbox is checked --}}
-        {{-- AC13: Added dusk="codpes-container" to the surrounding div --}}
-        <div x-show="$wire.email.toLowerCase().endsWith('usp.br') || $wire.sou_da_usp"
-             x-cloak {{-- Prevent flash of unstyled content --}}
-             x-transition
-             class="mt-4"
-             dusk="codpes-container">
-            <x-input-label for="codpes" :value="__('USP Number (codpes)')" dusk="codpes-label" />
-             {{-- AC13: Uses existing dusk selector 'codpes-input' from previous commit --}}
-            <x-text-input wire:model="codpes" id="codpes" class="block mt-1 w-full"
-                          type="text" {{-- Use text, validation handles numeric --}}
-                          inputmode="numeric" {{-- Hint for mobile keyboards --}}
-                          name="codpes"
-                          autocomplete="off"
-                          x-bind:required="$wire.email.toLowerCase().endsWith('usp.br') || $wire.sou_da_usp"
-                          dusk="codpes-input" />
-            <x-input-error :messages="$errors->get('codpes')" class="mt-2" dusk="codpes-error" />
-        </div>
-        {{-- --- END ADDED USP FIELDS --- --}}
+    <!-- Número USP (codpes) Field - Conditional -->
+    {{-- Show if email ends with @usp.br OR the checkbox is checked --}}
+    {{-- AC13: Added dusk="codpes-container" to the surrounding div --}}
+    <div x-show="$wire.email.toLowerCase().endsWith('usp.br') || $wire.sou_da_usp"
+         x-cloak {{-- Prevent flash of unstyled content --}}
+         x-transition
+         class="mt-4"
+         dusk="codpes-container">
+        <x-input-label for="codpes" :value="__('USP Number (codpes)')" dusk="codpes-label" />
+         {{-- AC13: Uses existing dusk selector 'codpes-input' from previous commit --}}
+        <x-text-input wire:model="codpes" id="codpes" class="block mt-1 w-full"
+                      type="text" {{-- Use text, validation handles numeric --}}
+                      inputmode="numeric" {{-- Hint for mobile keyboards --}}
+                      name="codpes"
+                      autocomplete="off"
+                      x-bind:required="$wire.email.toLowerCase().endsWith('usp.br') || $wire.sou_da_usp"
+                      dusk="codpes-input" />
+        <x-input-error :messages="$errors->get('codpes')" class="mt-2" dusk="codpes-error" />
+    </div>
+    {{-- --- END ADDED USP FIELDS --- --}}
 
 
-        <!-- Password -->
-        <div class="mt-4">
-            <x-input-label for="password" :value="__('Password')" dusk="password-label" />
-            <x-text-input wire:model="password" id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="new-password" dusk="password-input" />
-            <x-input-error :messages="$errors->get('password')" class="mt-2" dusk="password-error" />
-        </div>
+    <!-- Password -->
+    <div class="mt-4">
+        <x-input-label for="password" :value="__('Password')" dusk="password-label" />
+        <x-text-input wire:model="password" id="password" class="block mt-1 w-full"
+                        type="password"
+                        name="password"
+                        required autocomplete="new-password" dusk="password-input" />
+        <x-input-error :messages="$errors->get('password')" class="mt-2" dusk="password-error" />
+    </div>
 
-        <!-- Confirm Password -->
-        <div class="mt-4">
-            <x-input-label for="password_confirmation" :value="__('Confirm Password')" dusk="password-confirmation-label" />
-            <x-text-input wire:model="password_confirmation" id="password_confirmation" class="block mt-1 w-full"
-                            type="password"
-                            name="password_confirmation" required autocomplete="new-password" dusk="password-confirmation-input" />
-            <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" dusk="password-confirmation-error" />
-        </div>
+    <!-- Confirm Password -->
+    <div class="mt-4">
+        <x-input-label for="password_confirmation" :value="__('Confirm Password')" dusk="password-confirmation-label" />
+        <x-text-input wire:model="password_confirmation" id="password_confirmation" class="block mt-1 w-full"
+                        type="password"
+                        name="password_confirmation" required autocomplete="new-password" dusk="password-confirmation-input" />
+        <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" dusk="password-confirmation-error" />
+    </div>
 
-        <div class="flex items-center justify-end mt-4">
-            <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="{{ route('login.local') }}" wire:navigate dusk="already-registered-link">
-                {{ __('Already registered?') }}
-            </a>
-            <x-primary-button class="ms-4" dusk="register-button">
-                {{ __('Register') }}
-            </x-primary-button>
-        </div>
-    </form>
+    <div class="flex items-center justify-end mt-4">
+        <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="{{ route('login.local') }}" wire:navigate dusk="already-registered-link">
+            {{ __('Already registered?') }}
+        </a>
+        <x-primary-button class="ms-4" dusk="register-button">
+            {{ __('Register') }}
+        </x-primary-button>
+    </div>
+</form>
+
 </div>

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -88,14 +88,12 @@ new #[Layout('layouts.guest')] class extends Component
 
         $user = User::create($userData);
 
-        // AC7 / AC8 - Role assignment logic will go here later
-        // if ($this->sou_da_usp && isset($validated['codpes'])) {
-        // Assign 'usp_user' role (using spatie/laravel-permission)
-        // $user->assignRole('usp_user');
-        // } else {
-        // Assign 'external_user' role
-        // $user->assignRole('external_user');
-        // }
+        // AC7: Assign 'usp_user' role if USP user and Replicado validation was successful.
+        // The Replicado validation success is implied if we passed the validation rules for 'codpes'.
+        if ($this->sou_da_usp && isset($validated['codpes'])) {
+            $user->assignRole('usp_user');
+        }
+        // AC8 (external_user role assignment) will be implemented here later.
 
         event(new Registered($user));
 

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -88,12 +88,17 @@ new #[Layout('layouts.guest')] class extends Component
 
         $user = User::create($userData);
 
-        // AC7: Assign 'usp_user' role if USP user and Replicado validation was successful.
-        // The Replicado validation success is implied if we passed the validation rules for 'codpes'.
-        if ($this->sou_da_usp && isset($validated['codpes'])) {
-            $user->assignRole('usp_user');
+        // Assign role based on whether codpes was successfully validated and stored
+        if ($user->codpes !== null) {
+            // This implies $this->sou_da_usp was true, codpes was provided,
+            // and Replicado validation was successful.
+            $user->assignRole('usp_user'); // AC7
+        } else {
+            // This covers:
+            // 1. User is not from USP ($this->sou_da_usp was false).
+            // 2. User claimed to be from USP, but Replicado validation failed (mismatch or service error).
+            $user->assignRole('external_user'); // AC8
         }
-        // AC8 (external_user role assignment) will be implemented here later.
 
         event(new Registered($user));
 

--- a/templates/context_selectors/select-context-for-review-issue.txt
+++ b/templates/context_selectors/select-context-for-review-issue.txt
@@ -1,0 +1,37 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Com base na descrição da tarefa principal e no manifesto JSON fornecido, selecione os arquivos **MAIS RELEVANTES** do manifesto que fornecerão o contexto ótimo para a IA realizar a tarefa principal.
+
+**Tarefa Principal:** Revisar a Issue GitHub `__NUMERO_DA_ISSUE__` e gerar um corpo Markdown atualizado e completo para ela. A revisão deve considerar o estado atual do projeto, possíveis mudanças de rumo desde a criação da issue, e garantir que a descrição e os Critérios de Aceite estejam alinhados com as práticas e documentação atuais.
+
+**Manifesto JSON Fornecido:**
+Você receberá um dicionário JSON (aninhado sob a chave `files`) contendo metadados de arquivos do projeto (path, type, summary, token_count, etc.). Este manifesto JÁ FOI FILTRADO para excluir arquivos muito grandes.
+
+**Seu Processo de Seleção:**
+1.  Entenda profundamente o objetivo da **Tarefa Principal**: revisar e atualizar o corpo da Issue `__NUMERO_DA_ISSUE__`.
+2.  Analise os metadados de CADA arquivo no `manifest.json` fornecido (path, type, summary).
+3.  Selecione APENAS os arquivos CRÍTICOS que contenham:
+    *   **OBRIGATÓRIO:** Os detalhes completos da Issue `__NUMERO_DA_ISSUE__` (`github_issue___NUMERO_DA_ISSUE___details.json`) - a base da revisão.
+    *   **OBRIGATÓRIO:** Toda a documentação principal do projeto (`README.md`, todos os `docs/*.md`) para garantir alinhamento com padrões e guias atuais.
+    *   **ALTAMENTE RELEVANTE:** O estado atual do projeto: histórico recente (`git_log.txt`), status atual (`git_status.txt`), manifesto (`manifest.json` ou `_manifest.json`), estrutura (`project_tree_L*.txt`), rotas (`artisan_route_list.json`), dependências (`composer_show.txt`, `npm_list*`).
+    *   **ALTAMENTE RELEVANTE:** Outras Issues e PRs recentes (`gh_pr_list.txt`, outros `github_issue_*_details.json`) que possam indicar mudanças de contexto ou decisões relevantes.
+    *   **RELEVANTE (Se o `summary` indicar):** Código fonte (`app/...`, `resources/views/...`, `tests/...`) que seja *diretamente* relacionado ao *assunto* da Issue `__NUMERO_DA_ISSUE__`, para ajudar a avaliar se a descrição original ainda faz sentido.
+4.  **Priorize:** Detalhes da issue alvo, *toda* a documentação principal, estado atual do projeto e histórico recente são essenciais. Código fonte relacionado é útil, mas secundário à documentação para esta tarefa específica de *revisão da issue*.
+5.  **Exclua:** Arquivos de contexto muito antigos (se identificáveis), diffs específicos (a menos que o `summary` indique uma mudança crucial), arquivos de build, arquivos de configuração muito genéricos, a menos que seus `summary` indiquem relevância direta para a revisão da Issue `__NUMERO_DA_ISSUE__`.
+
+**Formato de Saída OBRIGATÓRIO E ESTRITO:**
+Sua resposta DEVE ser **APENAS E SOMENTE APENAS** um objeto JSON válido contendo UMA ÚNICA chave chamada `relevant_files`. O valor desta chave DEVE ser uma LISTA (array JSON) de strings, onde cada string é o caminho relativo EXATO de um arquivo selecionado do manifesto.
+
+**Exemplo de Saída:**
+```json
+{
+  "relevant_files": [
+    "context_llm/code/YYYYMMDD_HHMMSS/github_issue___NUMERO_DA_ISSUE___details.json",
+    "README.md",
+    "docs/guia_de_desenvolvimento.md",
+    "docs/padroes_codigo_boas_praticas.md",
+    "context_llm/code/YYYYMMDD_HHMMSS/git_log.txt",
+    "context_llm/code/YYYYMMDD_HHMMSS/manifest.json",
+    "context_llm/code/YYYYMMDD_HHMMSS/gh_pr_list.txt",
+    "app/Http/Controllers/MaybeRelatedController.php"
+  ]
+}

--- a/templates/meta-prompts/meta-prompt-review-issue.txt
+++ b/templates/meta-prompts/meta-prompt-review-issue.txt
@@ -1,0 +1,35 @@
+**Sua Tarefa ÚNICA e ABSOLUTAMENTE RESTRITA:**
+Crie **EXCLUSIVAMENTE** o texto de um **prompt final**. Este prompt final instruirá uma IA (a "IA Final") a revisar o corpo da Issue `__NUMERO_DA_ISSUE__` e gerar um novo corpo Markdown completo e atualizado para ela, **formatado como um bloco `KEY: VALUE` para um arquivo de plano `.txt`**. Utilize como base este meta-prompt e os arquivos de contexto anexados. **NÃO** inclua **NADA** além do texto puro e exato deste prompt final. **ZERO** introduções, **ZERO** explicações, **ZERO** comentários pré ou pós-prompt. Sua saída deve começar **IMEDIATAMENTE** com a primeira palavra do prompt final e terminar **IMEDIATAMENTE** com a última palavra dele. Qualquer caractere fora do texto do prompt final é **ESTRITAMENTE PROIBIDO**.
+
+**Instruções para a Construção do Prompt Final (QUE VOCÊ DEVE GERAR E NADA MAIS):**
+
+O prompt final que você gerar **DEVE** comandar **explicitamente** a IA Final a seguir **OBRIGATORIAMENTE, SEM EXCEÇÕES E COM MÁXIMA FIDELIDADE** as seguintes diretrizes ao gerar o bloco de texto do plano da issue revisada:
+
+1.  **Objetivo Principal:** Instrua a IA Final a analisar a Issue `__NUMERO_DA_ISSUE__` original (fornecida no contexto) e **todo o contexto atual do projeto** (documentação, logs, outras issues/PRs recentes) para gerar um **bloco de texto completo no formato `KEY: VALUE`**, representando a **versão revisada e atualizada** da Issue `__NUMERO_DA_ISSUE__`. Este bloco deve ser adequado para uso com `scripts/create_issue.py`.
+
+2.  **Análise Mandatória do Contexto:** Exija que a IA Final analise **TODOS** os arquivos de contexto anexados (especialmente `github_issue___NUMERO_DA_ISSUE___details.json`, `docs/*.md`, `README.md`, `git_log.txt`, `manifest.json`, `gh_pr_list.txt`) para entender:
+    *   O conteúdo original da Issue `__NUMERO_DA_ISSUE__`.
+    *   O estado atual do projeto e seu histórico recente.
+    *   Os padrões de documentação e desenvolvimento atuais (`guia_de_desenvolvimento.md`, etc.).
+    *   Possíveis mudanças de escopo ou entendimento que ocorreram desde a criação da issue.
+
+3.  **Geração do Bloco Revisado (Formato `KEY: VALUE`):**
+    *   A IA Final **DEVE** gerar o bloco de texto contendo as seguintes chaves, mantendo os valores originais da issue (`github_issue...json`) a menos que uma revisão seja necessária:
+        *   `TITLE:` **MANTENHA O TÍTULO ORIGINAL** da Issue `__NUMERO_DA_ISSUE__`.
+        *   `TYPE:` **MANTENHA O TIPO ORIGINAL** (feature, bug, chore, etc.).
+        *   `LABELS:` **MANTENHA AS LABELS ORIGINAIS**, mas **ADICIONE** a label `needs-review` se ainda não estiver presente.
+        *   `ASSIGNEE:` **MANTENHA O ASSIGNEE ORIGINAL**.
+        *   `PROJECT:` (Opcional) **MANTENHA O PROJETO ORIGINAL**, se houver.
+        *   `MILESTONE:` (Opcional) **MANTENHA O MILESTONE ORIGINAL**, se houver.
+        *   **(REVISAR/ATUALIZAR) BODY:** Esta é a parte principal. Instrua a IA Final a gerar um novo valor **Markdown completo** para a chave `BODY`. Este valor DEVE conter:
+            *   Uma seção clara explicando o **contexto/motivação** da issue (atualizada se necessário).
+            *   Uma **descrição detalhada** da funcionalidade/bug/tarefa, **revisada** para refletir o entendimento atual e o estado do projeto. Referencie as diretrizes em `guia_de_desenvolvimento.md`.
+            *   **(CRÍTICO) Critérios de Aceite (ACs):** Uma lista **revisada e completa** de ACs (`- [ ] ...`), garantindo que sejam **S.M.A.R.T.** (Específicos, Mensuráveis, Alcançáveis, Relevantes, Temporizáveis), **verificáveis** e alinhados com os padrões e código atuais. Remova ACs obsoletos, adicione novos se necessário, e refine a clareza dos existentes.
+            *   Outras seções relevantes do template original (ex: `PROPOSED_SOLUTION`), atualizadas conforme o contexto.
+    *   **PROIBIÇÃO ABSOLUTA DE REFERÊNCIAS DE CONTEXTO:** É **TERMINANTEMENTE PROIBIDO** mencionar nomes de arquivos de contexto (`.txt`, `.json`, etc., não versionados) no valor da chave `BODY`.
+
+4.  **Formatação da Saída Final da IA Final (EXTREMAMENTE IMPORTANTE):** O prompt final **DEVE ORDENAR CATEGORICAMENTE** à IA Final que sua resposta contenha **APENAS E SOMENTE APENAS** o texto puro do bloco de definição da issue revisada, formatado exatamente como `KEY: VALUE` por linha, com o valor `BODY` contendo Markdown válido e multi-linhas. **NENHUM caractere extra**, nenhuma explicação, nenhuma introdução, nenhum delimitador como `--- START BLOCK ---`. A resposta deve começar diretamente com `TITLE: ` e terminar imediatamente após a última linha do valor de `BODY:`.
+
+5.  **Baseado no Contexto:** Reafirme que a IA Final **DEVE** basear as *revisões* (especialmente no `BODY`) **UNICAMENTE** nas informações contidas nos arquivos de contexto fornecidos e nas regras documentadas.
+
+**REPETINDO SUA TAREFA:** Sua saída deve ser **APENAS** o texto do prompt final que instruirá a IA Final a gerar o bloco de texto do plano para a issue revisada, seguindo as diretrizes de formato de saída e utilizando os valores específicos (`__NUMERO_DA_ISSUE__`) que já estarão presentes neste meta-prompt quando você o processar. Comece a resposta diretamente com a primeira palavra do prompt final. Termine imediatamente após a última palavra. **NÃO ESCREVA MAIS NADA.**

--- a/templates/prompts/prompt-review-issue.txt
+++ b/templates/prompts/prompt-review-issue.txt
@@ -1,0 +1,19 @@
+Sua tarefa é analisar a Issue GitHub `__NUMERO_DA_ISSUE__` original (fornecida no contexto) e **todo o contexto atual do projeto** (documentação, logs, outras issues/PRs recentes) para gerar **APENAS E SOMENTE APENAS** um **corpo Markdown completo e revisado** para esta issue.
+
+**Analise TODOS os arquivos de contexto anexados** (especialmente `github_issue___NUMERO_DA_ISSUE___details.json`, `docs/*.md`, `README.md`, `git_log.txt`, `manifest.json`, `gh_pr_list.txt`, código fonte relevante) e siga **OBRIGATORIAMENTE** estas regras ao gerar o corpo Markdown:
+
+1.  **Revisão Completa:** Avalie o corpo original da Issue `__NUMERO_DA_ISSUE__`. Identifique se a descrição, o contexto, a solução proposta e, principalmente, os Critérios de Aceite (ACs) ainda são válidos, claros e alinhados com o estado atual do projeto e os padrões definidos em `guia_de_desenvolvimento.md` e `padroes_codigos_boas_praticas.md`.
+2.  **Conteúdo do Corpo Revisado:** O Markdown gerado **DEVE** incluir:
+    *   Uma seção clara explicando o **contexto/motivação** (atualizada se necessário).
+    *   Uma **descrição detalhada** da funcionalidade/bug/tarefa, **revisada** para refletir o entendimento atual.
+    *   **(CRÍTICO) Critérios de Aceite (ACs):** Uma lista **revisada e completa** de ACs (`- [ ] ...`), garantindo que sejam **S.M.A.R.T.**, **verificáveis** e alinhados com os padrões/código atuais. Remova/adicione/refine ACs conforme necessário.
+    *   Outras seções relevantes do template original, atualizadas.
+3.  **Estilo e Formato:** Mantenha o **mesmo estilo geral de formatação Markdown** do corpo original da issue.
+4.  **PROIBIÇÃO DE REFERÊNCIAS:** **NUNCA** mencione nomes de arquivos de contexto não versionados (`.txt`, `.json`, etc.) no corpo gerado.
+5.  **Baseado no Contexto:** Baseie **TODAS** as revisões **UNICAMENTE** no contexto fornecido.
+6.  **SAÍDA ESTRITAMENTE FORMATADA:** Sua resposta **DEVE** conter **APENAS E SOMENTE APENAS** o texto Markdown completo do corpo da issue revisado. **NENHUM** texto adicional (introdução, explicação, título, labels, etc.). Comece diretamente com a primeira linha do corpo Markdown (provavelmente um cabeçalho como `## Contexto / Motivação`). Termine imediatamente após a última linha do corpo revisado.
+
+**OBSERVAÇÃO ADICIONAL PRIORITÁRIA:**
+__OBSERVACAO_ADICIONAL__
+
+Execute a tarefa seguindo **TODAS** estas regras com **MÁXIMA FIDELIDADE**.

--- a/tests/Fakes/FakeReplicadoService.php
+++ b/tests/Fakes/FakeReplicadoService.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Fakes;
 
+use App\Exceptions\ReplicadoServiceException; // Import custom exception
 use App\Services\ReplicadoService;
-use Exception;
 
 /**
  * Fake implementation of ReplicadoService for testing purposes.
@@ -12,7 +12,7 @@ class FakeReplicadoService extends ReplicadoService
 {
     /**
      * Controls the return value of validarNuspEmail.
-     * true = success, false = validation failure, null = simulate service error.
+     * true = success, false = validation failure.
      */
     public ?bool $validationResult = true;
 
@@ -24,34 +24,40 @@ class FakeReplicadoService extends ReplicadoService
     /**
      * Simulates the validation logic.
      *
-     * @throws \Exception
+     * @param  int  $codpes
+     * @param  string  $email
+     * @return bool
+     *
+     * @throws \App\Exceptions\ReplicadoServiceException
      */
     public function validarNuspEmail(int $codpes, string $email): bool
     {
         if ($this->shouldThrowException) {
-            throw new Exception('Simulated Replicado service communication error.');
+            // Simulate a service communication error by throwing the custom exception
+            throw new ReplicadoServiceException('Simulated Replicado service communication error.');
         }
 
         // Return the predefined result (true for success, false for invalid)
-        return $this->validationResult ?? true; // Default to true if not set explicitly
+        // Default to true if not set explicitly, or handle as per specific test needs.
+        return $this->validationResult ?? true;
     }
 
     /**
      * Sets the desired validation result for the next call.
      *
-     * @param  bool|null  $result  true for success, false for failure, null to reset to default (true)
+     * @param  bool|null  $result  true for success, false for failure.
      * @return $this
      */
     public function shouldReturn(?bool $result): self
     {
         $this->validationResult = $result;
-        $this->shouldThrowException = false; // Ensure it doesn't throw exception
+        $this->shouldThrowException = false; // Ensure it doesn't throw an exception when a return value is set.
 
         return $this;
     }
 
     /**
-     * Configures the fake service to throw an exception on the next call.
+     * Configures the fake service to throw a ReplicadoServiceException on the next call.
      *
      * @return $this
      */

--- a/tests/Fakes/FakeReplicadoService.php
+++ b/tests/Fakes/FakeReplicadoService.php
@@ -24,9 +24,6 @@ class FakeReplicadoService extends ReplicadoService
     /**
      * Simulates the validation logic.
      *
-     * @param  int  $codpes
-     * @param  string  $email
-     * @return bool
      *
      * @throws \App\Exceptions\ReplicadoServiceException
      */

--- a/tests/Fakes/FakeReplicadoService.php
+++ b/tests/Fakes/FakeReplicadoService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Fakes;
+
+use App\Services\ReplicadoService;
+use Exception;
+
+/**
+ * Fake implementation of ReplicadoService for testing purposes.
+ */
+class FakeReplicadoService extends ReplicadoService
+{
+    /**
+     * Controls the return value of validarNuspEmail.
+     * true = success, false = validation failure, null = simulate service error.
+     */
+    public ?bool $validationResult = true;
+
+    /**
+     * Determines if the service should throw an exception.
+     */
+    public bool $shouldThrowException = false;
+
+    /**
+     * Simulates the validation logic.
+     *
+     * @throws \Exception
+     */
+    public function validarNuspEmail(int $codpes, string $email): bool
+    {
+        if ($this->shouldThrowException) {
+            throw new Exception('Simulated Replicado service communication error.');
+        }
+
+        // Return the predefined result (true for success, false for invalid)
+        return $this->validationResult ?? true; // Default to true if not set explicitly
+    }
+
+    /**
+     * Sets the desired validation result for the next call.
+     *
+     * @param  bool|null  $result  true for success, false for failure, null to reset to default (true)
+     * @return $this
+     */
+    public function shouldReturn(?bool $result): self
+    {
+        $this->validationResult = $result;
+        $this->shouldThrowException = false; // Ensure it doesn't throw exception
+
+        return $this;
+    }
+
+    /**
+     * Configures the fake service to throw an exception on the next call.
+     *
+     * @return $this
+     */
+    public function shouldFail(): self
+    {
+        $this->shouldThrowException = true;
+
+        return $this;
+    }
+}

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -99,8 +99,8 @@ class PasswordResetTest extends TestCase
         Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
             $component = Volt::test('pages.auth.reset-password', ['token' => $notification->token])
                 ->set('email', $user->email)
-                ->set('password', 'password') // Define a nova senha
-                ->set('password_confirmation', 'password'); // Confirma a nova senha
+                ->set('password', 'Password123!') // Define a nova senha
+                ->set('password_confirmation', 'Password123!'); // Confirma a nova senha
 
             // Chama a ação de resetar a senha
             $component->call('resetPassword');

--- a/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/tests/Feature/Auth/PasswordUpdateTest.php
@@ -20,15 +20,15 @@ class PasswordUpdateTest extends TestCase
 
         $component = Volt::test('profile.update-password-form')
             ->set('current_password', 'password')
-            ->set('password', 'new-password')
-            ->set('password_confirmation', 'new-password')
+            ->set('password', 'Password123!')
+            ->set('password_confirmation', 'Password123!')
             ->call('updatePassword');
 
         $component
             ->assertHasNoErrors()
             ->assertNoRedirect();
 
-        $this->assertTrue(Hash::check('new-password', $user->refresh()->password));
+        $this->assertTrue(Hash::check('Password123!', $user->refresh()->password));
     }
 
     public function test_correct_password_must_be_provided_to_update_password(): void

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -24,8 +24,8 @@ class RegistrationTest extends TestCase
         $component = Volt::test('pages.auth.register')
             ->set('name', 'Test User')
             ->set('email', 'test@example.com')
-            ->set('password', 'password')
-            ->set('password_confirmation', 'password');
+            ->set('password', 'Password123!')
+            ->set('password_confirmation', 'Password123!');
 
         $component->call('register');
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
+use Database\Seeders\RoleSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Volt\Volt;
 use Tests\TestCase;
@@ -9,6 +10,12 @@ use Tests\TestCase;
 class RegistrationTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+    }
 
     public function test_registration_screen_can_be_rendered(): void
     {

--- a/tests/Feature/Auth/RegistrationValidationTest.php
+++ b/tests/Feature/Auth/RegistrationValidationTest.php
@@ -3,14 +3,13 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
-use App\Services\ReplicadoService; // Import the actual service
+use App\Services\ReplicadoService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Validator; // Mantenha para o teste de regras padrão
-use Illuminate\Validation\Rule;  // Mantenha para o teste de regras padrão
-use Illuminate\Validation\Rules\Password; // Importe Volt
-use Livewire\Volt\Volt; // Import the fake service
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+use Livewire\Volt\Volt;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\Fakes\FakeReplicadoService; // Importe Rule para o teste de codpes
+use Tests\Fakes\FakeReplicadoService;
 use Tests\TestCase;
 
 class RegistrationValidationTest extends TestCase
@@ -25,12 +24,9 @@ class RegistrationValidationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        // Bind the fake service instance for ReplicadoService resolution
         $this->instance(ReplicadoService::class, new FakeReplicadoService);
     }
 
-    // Método para obter um email único para evitar falhas de 'unique'
     private function getUniqueEmail(bool $isUsp = false): string
     {
         $domain = $isUsp ? '@usp.br' : '@example.com';
@@ -38,17 +34,13 @@ class RegistrationValidationTest extends TestCase
         return 'test'.now()->timestamp.rand(100, 999).$domain;
     }
 
-    // Método para obter uma senha que passe nas regras padrão
-    // Adapte se suas regras forem diferentes
     private function getValidPassword(): string
     {
         return 'Password123!';
     }
 
-    // --- Testes para Cenários Válidos (shouldPass = true) ---
-
     #[Test]
-    public function test_valid_non_usp_user_can_register(): void
+    public function valid_non_usp_user_can_register(): void
     {
         $password = $this->getValidPassword();
 
@@ -57,36 +49,35 @@ class RegistrationValidationTest extends TestCase
             ->set('email', $this->getUniqueEmail())
             ->set('password', $password)
             ->set('password_confirmation', $password)
-            ->set('sou_da_usp', false) // Explicitamente não USP
-            ->set('codpes', '') // Não deve ser requerido
+            ->set('sou_da_usp', false)
+            ->set('codpes', '')
             ->call('register')
-            ->assertHasNoErrors() // Espera passar
+            ->assertHasNoErrors()
             ->assertRedirect(route('dashboard', absolute: false));
 
-        $this->assertAuthenticated(); // Verifica se logou
+        $this->assertAuthenticated();
     }
 
     #[Test]
-    public function test_valid_usp_user_with_codpes_and_successful_replicado_validation_can_register(): void
+    public function valid_usp_user_with_codpes_and_successful_replicado_validation_can_register(): void
     {
         $password = $this->getValidPassword();
         $uspEmail = $this->getUniqueEmail(true);
         $codpes = '1234567';
 
-        // Configure FakeReplicadoService to return true (success)
-        $fakeReplicadoService = app(ReplicadoService::class); // Get the bound fake instance
+        $fakeReplicadoService = app(ReplicadoService::class);
         $fakeReplicadoService->shouldReturn(true);
 
         $component = Volt::test('pages.auth.register')
             ->set('name', 'Test USP User Valid')
-            ->set('email', $uspEmail) // Email USP
-            ->assertSet('sou_da_usp', true) // Check if updatedEmail hook worked
+            ->set('email', $uspEmail)
+            ->assertSet('sou_da_usp', true)
             ->set('password', $password)
             ->set('password_confirmation', $password)
-            ->set('codpes', $codpes) // Codpes válido
+            ->set('codpes', $codpes)
             ->call('register');
 
-        $component->assertHasNoErrors() // Espera passar
+        $component->assertHasNoErrors()
             ->assertRedirect(route('dashboard', absolute: false));
 
         $this->assertAuthenticated();
@@ -97,14 +88,14 @@ class RegistrationValidationTest extends TestCase
     }
 
     #[Test]
-    public function test_valid_non_usp_user_with_optional_codpes_can_register(): void
+    public function valid_non_usp_user_with_optional_codpes_can_register(): void
     {
         $password = $this->getValidPassword();
-        $generatedEmail = $this->getUniqueEmail(); // <-- Captura o email
+        $generatedEmail = $this->getUniqueEmail();
 
         Volt::test('pages.auth.register')
             ->set('name', 'Test Non USP Optional Codpes')
-            ->set('email', $generatedEmail) // <-- Usa o email gerado
+            ->set('email', $generatedEmail)
             ->set('password', $password)
             ->set('password_confirmation', $password)
             ->set('sou_da_usp', false)
@@ -114,37 +105,32 @@ class RegistrationValidationTest extends TestCase
             ->assertRedirect(route('dashboard', absolute: false));
 
         $this->assertAuthenticated();
-
-        // Usa a variável local na asserção
         $this->assertDatabaseHas('users', [
-            'email' => $generatedEmail, // <-- Usa a variável local
-            'codpes' => null, // Codpes should be null for non-USP users even if provided
+            'email' => $generatedEmail,
+            'codpes' => null,
         ]);
     }
-    // --- Testes para Cenários Inválidos (shouldPass = false) ---
 
     #[Test]
-    public function test_registration_fails_when_name_is_missing(): void
+    public function registration_fails_when_name_is_missing(): void
     {
         $password = $this->getValidPassword();
 
         Volt::test('pages.auth.register')
-            // Não seta 'name'
             ->set('email', $this->getUniqueEmail())
             ->set('password', $password)
             ->set('password_confirmation', $password)
             ->call('register')
-            ->assertHasErrors(['name' => 'required']); // Espera erro específico
+            ->assertHasErrors(['name' => 'required']);
     }
 
     #[Test]
-    public function test_registration_fails_when_email_is_missing(): void
+    public function registration_fails_when_email_is_missing(): void
     {
         $password = $this->getValidPassword();
 
         Volt::test('pages.auth.register')
             ->set('name', 'Test Name')
-            // Não seta 'email'
             ->set('password', $password)
             ->set('password_confirmation', $password)
             ->call('register')
@@ -152,35 +138,33 @@ class RegistrationValidationTest extends TestCase
     }
 
     #[Test]
-    public function test_registration_fails_when_password_is_missing(): void
+    public function registration_fails_when_password_is_missing(): void
     {
         Volt::test('pages.auth.register')
             ->set('name', 'Test Name')
             ->set('email', $this->getUniqueEmail())
-            // Não seta 'password' nem 'password_confirmation'
             ->call('register')
-            ->assertHasErrors(['password' => 'required']); // A regra 'confirmed' também falhará, mas 'required' é a raiz
+            ->assertHasErrors(['password' => 'required']);
     }
 
     #[Test]
-    public function test_registration_fails_when_codpes_is_missing_for_usp_user(): void
+    public function registration_fails_when_codpes_is_missing_for_usp_user(): void
     {
         $password = $this->getValidPassword();
 
         Volt::test('pages.auth.register')
             ->set('name', 'Test USP User')
-            ->set('email', $this->getUniqueEmail(true)) // Email USP ativa sou_da_usp
-            ->assertSet('sou_da_usp', true) // Check hook
+            ->set('email', $this->getUniqueEmail(true))
+            ->assertSet('sou_da_usp', true)
             ->set('password', $password)
             ->set('password_confirmation', $password)
-            // ->set('sou_da_usp', true) // Garante que a flag USP está ativa (já é setada pelo email)
-            ->set('codpes', '') // Explicitamente vazio
+            ->set('codpes', '')
             ->call('register')
-            ->assertHasErrors(['codpes' => 'required']); // Verifica se a regra condicional falhou
+            ->assertHasErrors(['codpes' => 'required']);
     }
 
     #[Test]
-    public function test_registration_fails_when_codpes_is_empty_string_for_usp_user(): void
+    public function registration_fails_when_codpes_is_empty_string_for_usp_user(): void
     {
         $password = $this->getValidPassword();
 
@@ -190,43 +174,42 @@ class RegistrationValidationTest extends TestCase
             ->assertSet('sou_da_usp', true)
             ->set('password', $password)
             ->set('password_confirmation', $password)
-           // ->set('sou_da_usp', true)
-            ->set('codpes', '') // Codpes vazio
+            ->set('codpes', '')
             ->call('register')
             ->assertHasErrors(['codpes' => 'required']);
     }
 
     #[Test]
-    public function test_registration_fails_for_invalid_email_format(): void
+    public function registration_fails_for_invalid_email_format(): void
     {
         $password = $this->getValidPassword();
 
         Volt::test('pages.auth.register')
             ->set('name', 'Test Name')
-            ->set('email', 'invalid-email-format') // Formato inválido
+            ->set('email', 'invalid-email-format')
             ->set('password', $password)
             ->set('password_confirmation', $password)
             ->call('register')
-            ->assertHasErrors(['email' => 'email']); // Verifica a regra 'email'
+            ->assertHasErrors(['email' => 'email']);
     }
 
     #[Test]
-    public function test_registration_fails_when_email_is_already_taken(): void
+    public function registration_fails_when_email_is_already_taken(): void
     {
         $password = $this->getValidPassword();
-        $existingUser = User::factory()->create(); // Cria um usuário com um email
+        $existingUser = User::factory()->create();
 
         Volt::test('pages.auth.register')
             ->set('name', 'Another User')
-            ->set('email', $existingUser->email) // Usa o email existente
+            ->set('email', $existingUser->email)
             ->set('password', $password)
             ->set('password_confirmation', $password)
             ->call('register')
-            ->assertHasErrors(['email' => 'unique']); // Verifica a regra 'unique'
+            ->assertHasErrors(['email' => 'unique']);
     }
 
     #[Test]
-    public function test_registration_fails_when_password_confirmation_mismatches(): void
+    public function registration_fails_when_password_confirmation_mismatches(): void
     {
         $password = $this->getValidPassword();
 
@@ -234,13 +217,13 @@ class RegistrationValidationTest extends TestCase
             ->set('name', 'Test Name')
             ->set('email', $this->getUniqueEmail())
             ->set('password', $password)
-            ->set('password_confirmation', 'different-password') // Confirmação diferente
+            ->set('password_confirmation', 'different-password')
             ->call('register')
-            ->assertHasErrors(['password' => 'confirmed']); // Verifica a regra 'confirmed'
+            ->assertHasErrors(['password' => 'confirmed']);
     }
 
     #[Test]
-    public function test_registration_fails_when_password_is_too_short(): void
+    public function registration_fails_when_password_is_too_short(): void
     {
         Volt::test('pages.auth.register')
             ->set('name', 'Test Name')
@@ -248,12 +231,11 @@ class RegistrationValidationTest extends TestCase
             ->set('password', 'short')
             ->set('password_confirmation', 'short')
             ->call('register')
-            // ->assertHasErrors(['password' => 'min']); // <-- Linha antiga
-            ->assertHasErrors(['password']);           // <-- Nova linha: Verifica qualquer erro para 'password'
+            ->assertHasErrors(['password']);
     }
 
     #[Test]
-    public function test_registration_fails_when_codpes_is_not_numeric_for_usp_user(): void
+    public function registration_fails_when_codpes_is_not_numeric_for_usp_user(): void
     {
         $password = $this->getValidPassword();
 
@@ -263,14 +245,13 @@ class RegistrationValidationTest extends TestCase
             ->assertSet('sou_da_usp', true)
             ->set('password', $password)
             ->set('password_confirmation', $password)
-           // ->set('sou_da_usp', true)
-            ->set('codpes', 'ABCDEFG') // Não numérico
+            ->set('codpes', 'ABCDEFG')
             ->call('register')
             ->assertHasErrors(['codpes' => 'numeric']);
     }
 
     #[Test]
-    public function test_registration_fails_when_codpes_is_too_short_for_usp_user(): void
+    public function registration_fails_when_codpes_is_too_short_for_usp_user(): void
     {
         $password = $this->getValidPassword();
 
@@ -280,14 +261,13 @@ class RegistrationValidationTest extends TestCase
             ->assertSet('sou_da_usp', true)
             ->set('password', $password)
             ->set('password_confirmation', $password)
-            // ->set('sou_da_usp', true)
-            ->set('codpes', '12345') // Curto demais (definido como 6-8)
+            ->set('codpes', '12345')
             ->call('register')
             ->assertHasErrors(['codpes' => 'digits_between']);
     }
 
     #[Test]
-    public function test_registration_fails_when_codpes_is_too_long_for_usp_user(): void
+    public function registration_fails_when_codpes_is_too_long_for_usp_user(): void
     {
         $password = $this->getValidPassword();
 
@@ -297,22 +277,18 @@ class RegistrationValidationTest extends TestCase
             ->assertSet('sou_da_usp', true)
             ->set('password', $password)
             ->set('password_confirmation', $password)
-            // ->set('sou_da_usp', true)
-            ->set('codpes', '123456789') // Longo demais (definido como 6-8)
+            ->set('codpes', '123456789')
             ->call('register')
             ->assertHasErrors(['codpes' => 'digits_between']);
     }
 
-    // --- AC3/AC4 Specific Tests ---
-
     #[Test]
-    public function test_registration_fails_when_replicado_validation_fails_for_usp_user(): void
+    public function registration_fails_when_replicado_validation_fails_for_usp_user(): void
     {
         $password = $this->getValidPassword();
         $uspEmail = $this->getUniqueEmail(true);
-        $codpes = '1234567'; // Valid format, but Replicado will say it's wrong
+        $codpes = '1234567';
 
-        // Configure FakeReplicadoService to return false (validation failure)
         $fakeReplicadoService = app(ReplicadoService::class);
         $fakeReplicadoService->shouldReturn(false);
 
@@ -324,22 +300,21 @@ class RegistrationValidationTest extends TestCase
             ->set('password_confirmation', $password)
             ->set('codpes', $codpes)
             ->call('register')
-            ->assertHasErrors(['codpes' => 'validation.custom.replicado_validation_failed']); // AC4: Check for the specific custom error message key
+            ->assertHasErrors(['codpes' => 'validation.custom.codpes.replicado_validation_failed']);
 
-        $this->assertGuest(); // User should not be authenticated or created
+        $this->assertGuest();
         $this->assertDatabaseMissing('users', ['email' => $uspEmail]);
     }
 
     #[Test]
-    public function test_registration_fails_when_replicado_service_is_unavailable_for_usp_user(): void
+    public function registration_fails_when_replicado_service_is_unavailable_for_usp_user(): void
     {
         $password = $this->getValidPassword();
         $uspEmail = $this->getUniqueEmail(true);
         $codpes = '1234567';
 
-        // Configure FakeReplicadoService to throw an exception
         $fakeReplicadoService = app(ReplicadoService::class);
-        $fakeReplicadoService->shouldFail();
+        $fakeReplicadoService->shouldFail(); // This configures FakeReplicadoService to throw ReplicadoServiceException
 
         Volt::test('pages.auth.register')
             ->set('name', 'Test USP User Replicado Error')
@@ -349,45 +324,37 @@ class RegistrationValidationTest extends TestCase
             ->set('password_confirmation', $password)
             ->set('codpes', $codpes)
             ->call('register')
-             // Check for the specific error message key related to service unavailability
-            ->assertHasErrors(['codpes' => 'validation.custom.replicado_service_unavailable']);
+            ->assertHasErrors(['codpes' => 'validation.custom.codpes.replicado_service_unavailable']);
 
-        $this->assertGuest(); // User should not be authenticated or created
+        $this->assertGuest();
         $this->assertDatabaseMissing('users', ['email' => $uspEmail]);
     }
 
-    // Mantém este teste isolado para verificar as regras padrão
     #[Test]
-    public function test_default_password_rules_meet_requirements(): void
+    public function default_password_rules_meet_requirements(): void
     {
         $rule = Password::defaults();
 
-        // Verifica Mínimo (ex: 8)
         $validatorShort = Validator::make(['password' => '1234567'], ['password' => $rule]);
         $this->assertTrue($validatorShort->fails());
         $this->assertArrayHasKey('password', $validatorShort->errors()->toArray());
 
-        // Verifica Letras (deve falhar se letras são exigidas pelas suas regras)
         $validatorNoLetter = Validator::make(['password' => '12345678!'], ['password' => $rule]);
         $this->assertTrue($validatorNoLetter->fails(), 'Default password rule should require letters.');
         $this->assertArrayHasKey('password', $validatorNoLetter->errors()->toArray());
 
-        // Verifica Números (deve falhar se números são exigidos)
         $validatorNoNumber = Validator::make(['password' => 'Password!'], ['password' => $rule]);
         $this->assertTrue($validatorNoNumber->fails(), 'Default password rule should require numbers.');
         $this->assertArrayHasKey('password', $validatorNoNumber->errors()->toArray());
 
-        // Verifica Símbolos (deve falhar se símbolos são exigidos)
         $validatorNoSymbol = Validator::make(['password' => 'Password123'], ['password' => $rule]);
         $this->assertTrue($validatorNoSymbol->fails(), 'Default password rule should require symbols.');
         $this->assertArrayHasKey('password', $validatorNoSymbol->errors()->toArray());
 
-        // Verifica Caixa Mista (deve falhar se exigido)
         $validatorNoMixedCase = Validator::make(['password' => 'password123!'], ['password' => $rule]);
         $this->assertTrue($validatorNoMixedCase->fails(), 'Default password rule should require mixed case.');
         $this->assertArrayHasKey('password', $validatorNoMixedCase->errors()->toArray());
 
-        // Verifica uma senha válida (deve passar)
         $validatorValid = Validator::make(['password' => $this->getValidPassword()], ['password' => $rule]);
         $this->assertFalse($validatorValid->fails(), 'A valid password should pass default rules.');
     }

--- a/tests/Feature/Auth/RegistrationValidationTest.php
+++ b/tests/Feature/Auth/RegistrationValidationTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator; // Mantenha para o teste de regras padrão
+use Illuminate\Validation\Rules\Password;  // Mantenha para o teste de regras padrão
+use Livewire\Volt\Volt; // Importe Volt
+use Tests\TestCase;
+use Illuminate\Validation\Rule; // Importe Rule para o teste de codpes
+
+class RegistrationValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // Método para obter um email único para evitar falhas de 'unique'
+    private function getUniqueEmail(): string
+    {
+        return 'test' . now()->timestamp . rand(100, 999) . '@example.com';
+    }
+
+    // Método para obter uma senha que passe nas regras padrão
+    // Adapte se suas regras forem diferentes
+    private function getValidPassword(): string
+    {
+        return 'Password123!';
+    }
+
+    // --- Testes para Cenários Válidos (shouldPass = true) ---
+
+    #[Test]
+    public function test_valid_non_usp_user_can_register(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test Non USP')
+            ->set('email', $this->getUniqueEmail())
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->set('sou_da_usp', false) // Explicitamente não USP
+            ->set('codpes', '') // Não deve ser requerido
+            ->call('register')
+            ->assertHasNoErrors() // Espera passar
+            ->assertRedirect(route('dashboard', absolute: false));
+
+        $this->assertAuthenticated(); // Verifica se logou
+    }
+
+    #[Test]
+    public function test_valid_usp_user_with_codpes_can_register(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test USP User')
+            ->set('email', 'test' . now()->timestamp . '@usp.br') // Email USP
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            // ->set('sou_da_usp', true) // Deveria ser setado automaticamente pelo updatedEmail
+            ->set('codpes', '1234567') // Codpes válido
+            ->call('register')
+            ->assertHasNoErrors() // Espera passar
+            ->assertRedirect(route('dashboard', absolute: false));
+
+         $this->assertAuthenticated();
+    }
+
+    #[Test]
+    public function test_valid_non_usp_user_with_optional_codpes_can_register(): void
+    {
+        $password = $this->getValidPassword();
+        $generatedEmail = $this->getUniqueEmail(); // <-- Captura o email
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test Non USP Optional Codpes')
+            ->set('email', $generatedEmail) // <-- Usa o email gerado
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->set('sou_da_usp', false)
+            ->set('codpes', '9876543')
+            ->call('register')
+            ->assertHasNoErrors()
+            ->assertRedirect(route('dashboard', absolute: false));
+
+         $this->assertAuthenticated();
+
+         // Usa a variável local na asserção
+         $this->assertDatabaseHas('users', [
+            'email' => $generatedEmail, // <-- Usa a variável local
+            'codpes' => null
+         ]);
+    }
+    // --- Testes para Cenários Inválidos (shouldPass = false) ---
+
+    #[Test]
+    public function test_registration_fails_when_name_is_missing(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            // Não seta 'name'
+            ->set('email', $this->getUniqueEmail())
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->call('register')
+            ->assertHasErrors(['name' => 'required']); // Espera erro específico
+    }
+
+    #[Test]
+    public function test_registration_fails_when_email_is_missing(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test Name')
+            // Não seta 'email'
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->call('register')
+            ->assertHasErrors(['email' => 'required']);
+    }
+
+     #[Test]
+    public function test_registration_fails_when_password_is_missing(): void
+    {
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test Name')
+            ->set('email', $this->getUniqueEmail())
+            // Não seta 'password' nem 'password_confirmation'
+            ->call('register')
+            ->assertHasErrors(['password' => 'required']); // A regra 'confirmed' também falhará, mas 'required' é a raiz
+    }
+
+     #[Test]
+    public function test_registration_fails_when_codpes_is_missing_for_usp_user(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test USP User')
+            ->set('email', 'test' . now()->timestamp . '@usp.br') // Email USP ativa sou_da_usp
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+             ->set('sou_da_usp', true) // Garante que a flag USP está ativa
+            // Não seta 'codpes'
+            ->call('register')
+            ->assertHasErrors(['codpes' => 'required']); // Verifica se a regra condicional falhou
+    }
+
+    #[Test]
+    public function test_registration_fails_when_codpes_is_empty_string_for_usp_user(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test USP User Empty Codpes')
+            ->set('email', 'test' . now()->timestamp . '@usp.br')
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->set('sou_da_usp', true)
+            ->set('codpes', '') // Codpes vazio
+            ->call('register')
+            ->assertHasErrors(['codpes' => 'required']);
+    }
+
+
+    #[Test]
+    public function test_registration_fails_for_invalid_email_format(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test Name')
+            ->set('email', 'invalid-email-format') // Formato inválido
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->call('register')
+            ->assertHasErrors(['email' => 'email']); // Verifica a regra 'email'
+    }
+
+    #[Test]
+    public function test_registration_fails_when_email_is_already_taken(): void
+    {
+        $password = $this->getValidPassword();
+        $existingUser = User::factory()->create(); // Cria um usuário com um email
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Another User')
+            ->set('email', $existingUser->email) // Usa o email existente
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->call('register')
+            ->assertHasErrors(['email' => 'unique']); // Verifica a regra 'unique'
+    }
+
+    #[Test]
+    public function test_registration_fails_when_password_confirmation_mismatches(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test Name')
+            ->set('email', $this->getUniqueEmail())
+            ->set('password', $password)
+            ->set('password_confirmation', 'different-password') // Confirmação diferente
+            ->call('register')
+            ->assertHasErrors(['password' => 'confirmed']); // Verifica a regra 'confirmed'
+    }
+
+    #[Test]
+    public function test_registration_fails_when_password_is_too_short(): void
+    {
+        Volt::test('pages.auth.register')
+            // ... (sets for name, email) ...
+            ->set('password', 'short')
+            ->set('password_confirmation', 'short')
+            ->call('register')
+            // ->assertHasErrors(['password' => 'min']); // <-- Linha antiga
+            ->assertHasErrors(['password']);           // <-- Nova linha: Verifica qualquer erro para 'password'
+    }
+
+    #[Test]
+    public function test_registration_fails_when_codpes_is_not_numeric_for_usp_user(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test USP User NonNumeric')
+            ->set('email', 'test' . now()->timestamp . '@usp.br')
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->set('sou_da_usp', true)
+            ->set('codpes', 'ABCDEFG') // Não numérico
+            ->call('register')
+            ->assertHasErrors(['codpes' => 'numeric']);
+    }
+
+     #[Test]
+    public function test_registration_fails_when_codpes_is_too_short_for_usp_user(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test USP User Short Codpes')
+            ->set('email', 'test' . now()->timestamp . '@usp.br')
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->set('sou_da_usp', true)
+            ->set('codpes', '12345') // Curto demais (definido como 6-8)
+            ->call('register')
+            ->assertHasErrors(['codpes' => 'digits_between']);
+    }
+
+    #[Test]
+    public function test_registration_fails_when_codpes_is_too_long_for_usp_user(): void
+    {
+        $password = $this->getValidPassword();
+
+        Volt::test('pages.auth.register')
+            ->set('name', 'Test USP User Long Codpes')
+            ->set('email', 'test' . now()->timestamp . '@usp.br')
+            ->set('password', $password)
+            ->set('password_confirmation', $password)
+            ->set('sou_da_usp', true)
+            ->set('codpes', '123456789') // Longo demais (definido como 6-8)
+            ->call('register')
+            ->assertHasErrors(['codpes' => 'digits_between']);
+    }
+
+
+    // Mantém este teste isolado para verificar as regras padrão
+    #[Test]
+    public function test_default_password_rules_meet_requirements(): void
+    {
+        $rule = Password::defaults();
+
+        // Verifica Mínimo (ex: 8)
+        $validatorShort = Validator::make(['password' => '1234567'], ['password' => $rule]);
+        $this->assertTrue($validatorShort->fails());
+        $this->assertArrayHasKey('password', $validatorShort->errors()->toArray());
+
+        // Verifica Letras (deve falhar se letras são exigidas pelas suas regras)
+        $validatorNoLetter = Validator::make(['password' => '12345678!'], ['password' => $rule]);
+        $this->assertTrue($validatorNoLetter->fails(), 'Default password rule should require letters.');
+        $this->assertArrayHasKey('password', $validatorNoLetter->errors()->toArray());
+
+        // Verifica Números (deve falhar se números são exigidos)
+        $validatorNoNumber = Validator::make(['password' => 'Password!'], ['password' => $rule]);
+        $this->assertTrue($validatorNoNumber->fails(), 'Default password rule should require numbers.');
+        $this->assertArrayHasKey('password', $validatorNoNumber->errors()->toArray());
+
+        // Verifica Símbolos (deve falhar se símbolos são exigidos)
+         $validatorNoSymbol = Validator::make(['password' => 'Password123'], ['password' => $rule]);
+         $this->assertTrue($validatorNoSymbol->fails(), 'Default password rule should require symbols.');
+         $this->assertArrayHasKey('password', $validatorNoSymbol->errors()->toArray());
+
+         // Verifica Caixa Mista (deve falhar se exigido)
+         $validatorNoMixedCase = Validator::make(['password' => 'password123!'], ['password' => $rule]);
+         $this->assertTrue($validatorNoMixedCase->fails(), 'Default password rule should require mixed case.');
+         $this->assertArrayHasKey('password', $validatorNoMixedCase->errors()->toArray());
+
+        // Verifica uma senha válida (deve passar)
+        $validatorValid = Validator::make(['password' => $this->getValidPassword()], ['password' => $rule]);
+        $this->assertFalse($validatorValid->fails(), 'A valid password should pass default rules.');
+    }
+}

--- a/tests/Feature/Auth/RegistrationValidationTest.php
+++ b/tests/Feature/Auth/RegistrationValidationTest.php
@@ -303,7 +303,7 @@ class RegistrationValidationTest extends TestCase
             ->assertHasErrors(['codpes' => 'digits_between']);
     }
 
-    // --- AC3/AC4/AC5 Specific Tests ---
+    // --- AC3/AC4 Specific Tests ---
 
     #[Test]
     public function test_registration_fails_when_replicado_validation_fails_for_usp_user(): void
@@ -324,7 +324,7 @@ class RegistrationValidationTest extends TestCase
             ->set('password_confirmation', $password)
             ->set('codpes', $codpes)
             ->call('register')
-            ->assertHasErrors(['codpes' => 'validation.custom.replicado_validation_failed']); // Check for the specific custom error message key
+            ->assertHasErrors(['codpes' => 'validation.custom.replicado_validation_failed']); // AC4: Check for the specific custom error message key
 
         $this->assertGuest(); // User should not be authenticated or created
         $this->assertDatabaseMissing('users', ['email' => $uspEmail]);

--- a/tests/Feature/Auth/RegistrationValidationTest.php
+++ b/tests/Feature/Auth/RegistrationValidationTest.php
@@ -65,8 +65,8 @@ class RegistrationValidationTest extends TestCase
         $this->assertNotNull($user);
         $this->assertEquals($name, $user->name);
         $this->assertNull($user->codpes);
-        // $this->assertTrue($user->hasRole('external_user')); // For AC8
-        $this->assertFalse($user->hasRole('usp_user'));
+        $this->assertTrue($user->hasRole('external_user'), "User should have 'external_user' role.");
+        $this->assertFalse($user->hasRole('usp_user'), "User should not have 'usp_user' role.");
     }
 
     #[Test]
@@ -127,8 +127,8 @@ class RegistrationValidationTest extends TestCase
         $this->assertNotNull($user);
         $this->assertEquals($name, $user->name);
         $this->assertNull($user->codpes); // Correctly null because sou_da_usp is false
-        // $this->assertTrue($user->hasRole('external_user')); // For AC8
-        $this->assertFalse($user->hasRole('usp_user'));
+        $this->assertTrue($user->hasRole('external_user'), "User should have 'external_user' role.");
+        $this->assertFalse($user->hasRole('usp_user'), "User should not have 'usp_user' role.");
     }
 
     #[Test]


### PR DESCRIPTION
Este Pull Request implementa a funcionalidade de registro de usuários locais no backend, conforme especificado na Issue #25. O objetivo principal é permitir que novos usuários se registrem na plataforma, diferenciando entre usuários da USP (que são validados através do serviço Replicado) e usuários externos, atribuindo-lhes os papéis (`roles`) adequados.

As principais alterações incluem:

*   **Validação no Componente de Registro:** Implementação das regras de validação diretamente no componente Livewire/Volt `pages.auth.register` para os campos do formulário (`name`, `email`, `password`, `sou_da_usp`, `codpes`), incluindo a validação condicional do campo `codpes`.
*   **Integração com ReplicadoService:** Adição de uma validação customizada que utiliza o `ReplicadoService` para verificar a autenticidade de usuários que se identificam como da USP, comparando `codpes` e `email`.
*   **Tratamento de Erros do Replicado:** Implementação de tratamento específico para cenários de falha na validação do Replicado (dados inválidos) e indisponibilidade do serviço, retornando mensagens de erro apropriadas ao usuário.
*   **Criação de Usuário e Persistência de Dados:** Lógica para criar o novo usuário na tabela `users`, armazenando o `codpes` de forma condicional para usuários USP.
*   **Atribuição de Roles:** Atribuição automática dos roles `usp_user` (para usuários USP validados) ou `external_user` (para usuários externos) no guard `web`.
*   **Eventos e Fluxo Pós-Registro:** Disparo do evento `Illuminate\Auth\Events\Registered` após a criação bem-sucedida do usuário, seguido pelo login automático e redirecionamento para o `dashboard`.
*   **Documentação Interna:** Adição de DocBlocks para as classes e métodos relevantes modificados ou criados.
*   **Testes de Feature:** Desenvolvimento de testes de feature (PHPUnit) abrangentes em `RegistrationValidationTest.php` para cobrir os diversos cenários de registro, incluindo sucesso e falha para usuários USP e externos, simulação de interações com o `ReplicadoService` (via `FakeReplicadoService`) e verificação do disparo de eventos.

Closes #25